### PR TITLE
Use configuration template from the BSP layer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,27 +62,22 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", privileged: false, args: [manifest, branch], inline: <<-SHELL
         MANIFEST=$1
         BRANCH=$2
-        export CONFDIR=/home/vagrant/pelux_yocto/build/conf
 
         # Clone recipes
         mkdir pelux_yocto
         cd pelux_yocto
         time repo init -u https://github.com/pelagicore/pelux-manifests.git -m $MANIFEST -b $BRANCH
         time repo sync
-
-        # Tweak configs
-        cp "$CONFDIR/local.conf.sample" "$CONFDIR/local.conf"
-        cp "$CONFDIR/bblayers.conf.sample" "$CONFDIR/bblayers.conf"
-        sed -i 's:<Yocto root>:/home/vagrant/pelux_yocto/:' "$CONFDIR/bblayers.conf"
     SHELL
 
     # Fetch the sources
     config.vm.provision "shell",
         args: ["/home/vagrant/pelux_yocto", "core-image-pelux"],
         privileged: false,
+        env: {"TEMPLATECONF" => "/home/vagrant/pelux_yocto/sources/meta-pelux-bsp-intel/conf"},
         path: "vagrant-cookbook/yocto/fetch-sources-for-recipes.sh"
 
-    # Build the kernel
+    # Build the image
     config.vm.provision "shell",
         args: ["/home/vagrant/pelux_yocto/", "core-image-pelux"],
         privileged: false,

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -19,7 +19,6 @@
   <project remote="yocto" revision="krogoth" name="meta-intel"                          path="sources/meta-intel"/>
   <project remote="github" revision="master"  name="Pelagicore/meta-pelux-bsp-intel" path="sources/meta-pelux-bsp-intel" />
   <project remote="github" revision="master"  name="Pelagicore/meta-pelux"           path="sources/meta-pelux" />
-  <project remote="github" revision="master"  name="Pelagicore/pelux-intel-base"     path="build/conf" />
 
   <!-- GENIVI stuff -->
   <project remote="yocto" revision="11.0" name="meta-ivi" path="sources/meta-ivi" />


### PR DESCRIPTION
Use Yocto environment variable TEMPLATECONF to pass sample configuration files.
Also, no more need for a special repository/layer with only configuration templates.

Signed-off-by: Igor Socec <igor.socec@pelagicore.com>