### PR TITLE
Refactor manifests into base and bsp

### DIFF
--- a/pelux-base.xml
+++ b/pelux-base.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <!-- Settings -->
+  <default sync-j="4" revision="krogoth" />
+
+  <!-- Remotes -->
+  <remote fetch="git://git.openembedded.org"    name="oe"/>
+  <remote fetch="git://git.yoctoproject.org"    name="yocto"/>
+  <remote fetch="git://github.com/"             name="github"/>
+
+  <!-- Base stuff -->
+  <project remote="oe"     revision="krogoth" name="meta-openembedded"      path="sources/meta-openembedded"/>
+  <project remote="yocto"  revision="krogoth" name="poky"                   path="sources/poky"/>
+  <project remote="github" revision="master"  name="Pelagicore/meta-bistro" path="sources/meta-bistro" />
+  <project remote="yocto"  revision="krogoth" name="meta-virtualization"    path="sources/meta-virtualization"/>
+
+  <project remote="github" revision="master"  name="Pelagicore/meta-pelux"           path="sources/meta-pelux" />
+
+  <!-- GENIVI stuff -->
+  <project remote="yocto" revision="11.0" name="meta-ivi" path="sources/meta-ivi" />
+
+  <!-- Qt Support stuff -->
+  <project remote="github" revision="krogoth" name="meta-qt5/meta-qt5" path="sources/meta-qt5"/>
+
+</manifest>

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -1,29 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
+  <include name="pelux-base.xml"/>
+
   <!-- Settings -->
   <default sync-j="4" revision="krogoth" />
 
-  <!-- Remotes -->
-  <remote fetch="git://git.openembedded.org"    name="oe"/>
-  <remote fetch="git://git.yoctoproject.org"    name="yocto"/>
-  <remote fetch="git://github.com/"             name="github"/>
-
-  <!-- Base stuff -->
-  <project remote="oe"     revision="krogoth" name="meta-openembedded"      path="sources/meta-openembedded"/>
-  <project remote="yocto"  revision="krogoth" name="poky"                   path="sources/poky"/>
-  <project remote="github" revision="master"  name="Pelagicore/meta-bistro" path="sources/meta-bistro" />
-  <project remote="yocto"  revision="krogoth" name="meta-virtualization"    path="sources/meta-virtualization"/>
-
   <!-- Target stuff -->
-  <project remote="yocto" revision="krogoth" name="meta-intel"                          path="sources/meta-intel"/>
+  <project remote="yocto"  revision="krogoth" name="meta-intel"                      path="sources/meta-intel"/>
   <project remote="github" revision="master"  name="Pelagicore/meta-pelux-bsp-intel" path="sources/meta-pelux-bsp-intel" />
-  <project remote="github" revision="master"  name="Pelagicore/meta-pelux"           path="sources/meta-pelux" />
-
-  <!-- GENIVI stuff -->
-  <project remote="yocto" revision="11.0" name="meta-ivi" path="sources/meta-ivi" />
-
-  <!-- Qt/Support stuff -->
-  <project remote="github" revision="krogoth" name="meta-qt5/meta-qt5" path="sources/meta-qt5"/>
 
 </manifest>


### PR DESCRIPTION
Separate pelux-intel.xml into pelux-base.xml and pelux-intel.xml. Where
"pelux-base.xml" speicifies things that will be included in every pelux build
and "pelux-intel.xml" includes "pelux-base.xml" and adds bsp specifics.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>