### PR TITLE
CONTRIBUTING: Add reference GNOME git guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ We are happy to accept contributions. To accept a contribution we require:
     - A "signed-off-by" line in the commits is interpreted as a DCO from our perspective
     - Use your real name and e-mail address
 
+We aim to follow the [GNOME guidelines](https://wiki.gnome.org/Git/CommitMessages) for commit
+messages.
+
+PELUX-manifests is open source software, see the LICENSE file to understand what license we use
+and what this means.
+
 Adding issues
 -------------
 Please provide the following information when filing issues:


### PR DESCRIPTION
Add a reference to the GNOME git guidelines which all commits in this
git repository should strive to follow.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>