### PR TITLE
intel-bsp: bump to version with conf-notes

### DIFF
--- a/pelux-intel-qt.xml
+++ b/pelux-intel-qt.xml
@@ -8,7 +8,7 @@
   <remove-project name="Pelagicore/meta-pelux-bsp-intel" />
   <project name="Pelagicore/meta-pelux-bsp-intel"
            remote="github"
-           revision="4a09dc1af36adf7391b9adb9eabef1c1d156c5c7"
+           revision="56a31d5fd8a9c3c161c54fcce58758a388c0bdbc"
            path="sources/meta-pelux-bsp-intel">
 
       <copyfile src="conf-qt/bblayers.conf.sample"

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -10,7 +10,7 @@
            path="sources/meta-intel"/>
 
   <project remote="github"
-           revision="4a09dc1af36adf7391b9adb9eabef1c1d156c5c7"
+           revision="56a31d5fd8a9c3c161c54fcce58758a388c0bdbc"
            name="Pelagicore/meta-pelux-bsp-intel"
            path="sources/meta-pelux-bsp-intel" />
 


### PR DESCRIPTION
Bump meta-pelux-intel-bsp to a version with conf-notes presenting
available PELUX images when setting the TEMPLATECONF.

This commit is a part of issue #27

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>