### PR TITLE
WIP: Vagrantfile: add possibility to use TEMPLATECONF from other BSP layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Building an Image
 
 The following manifests can be used for a build:
 
-* `pelux-intel.xml` - For building the `core-image-pelux` image
+* `pelux-intel.xml` - For building the `core-image-pelux` image for Intel
 * `pelux-intel-qt.xml` - For building the `core-image-pelux-qt` image, which is the baseline with QtAS
+* `pelux-rpi.xml` - For building the `core-image-pelux`image for Raspberry Pi 3
 
 An image build can be started using a virtual machine, see section "Using vagrant", or using `repo` tool
 directly, see section "Using Repo tool".
@@ -60,7 +61,8 @@ repo sync
 ```
 
 When done fetching the sources, create a build directory and set up bitbake. TEMPLATECONF tells the
-`oe-init-build-env` script which path to fetch configuration samples from.
+`oe-init-build-env` script which path to fetch configuration samples from. Note that the example below
+get the template configuration for the Intel BSP, adapt the path according to your current BSP.
 ```bash
 TEMPLATECONF=`pwd`/sources/meta-pelux-bsp-intel/conf/ source sources/poky/oe-init-build-env build
 ```
@@ -84,6 +86,9 @@ Reference instance for the Intel i7 x86 platform. Examples of boards using this 
 
 * Intel NUC
 * Minnowboard
+
+### Pelux Raspberry Pi
+Reference instance for Raspberry Pi 3
 
 Branching
 ---------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,9 @@ if (manifest.nil? || manifest == 0)
     abort("MANIFEST must be specified")
 end
 
+# Extract BSP name from manifest name, expects the format pelux-<BSP>-* or pelux-<BSP>.*
+bsp = manifest[/pelux-([^-]*)(-|\.).*/,1]
+
 bitbake_image = ENV['BITBAKE_IMAGE']
 
 if (bitbake_image.nil? || bitbake_image == 0)
@@ -93,7 +96,7 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell",
         args: ["/home/vagrant/pelux_yocto", "core-image-pelux"],
         privileged: false,
-        env: {"TEMPLATECONF" => "/home/vagrant/pelux_yocto/sources/meta-pelux-bsp-intel/conf"},
+        env: {"TEMPLATECONF" => "/home/vagrant/pelux_yocto/sources/meta-pelux-bsp-" + bsp + "/conf"},
         path: "vagrant-cookbook/yocto/fetch-sources-for-recipes.sh"
 
     # Build the image


### PR DESCRIPTION
This fixes https://github.com/Pelagicore/pelux-manifests/issues/22. 

It will now try to get TEMPLATECONF from meta-pelux-bsp-<BSP> where BSP is set as an environment variable in the same way MANIFEST and BITBAKE_IMAGE are passed. I made BSP default to intel if nothing is set to not break any previous behavior, but maybe we want to force this input?

Instead of specifying BSP we could also enforce a strict naming scheme of manifests, so that the bsp-name can be extracted from there. Like pelux-\<BSP\>-whatever, but that might just be confusing for future users?