### PR TITLE
pelux-intel-*: update meta-pelux-bsp-intel and add info about updating

### DIFF
--- a/pelux-intel-qt.xml
+++ b/pelux-intel-qt.xml
@@ -5,10 +5,11 @@
   <include name="pelux-qt.xml"/>
 
   <!-- Redefining meta-pelux-bsp-intel to add copyfile instructions -->
+  <!-- When updating this, also update pelux-intel.xml -->
   <remove-project name="Pelagicore/meta-pelux-bsp-intel" />
   <project name="Pelagicore/meta-pelux-bsp-intel"
            remote="github"
-           revision="56a31d5fd8a9c3c161c54fcce58758a388c0bdbc"
+           revision="6574ca1b6112e912dcb2ec474056d101797187d3"
            path="sources/meta-pelux-bsp-intel">
 
       <copyfile src="conf-qt/bblayers.conf.sample"

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -9,8 +9,9 @@
            name="meta-intel"
            path="sources/meta-intel"/>
 
+  <!-- When updating this, also update pelux-intel-qt.xml -->
   <project remote="github"
-           revision="0f82473e8f9c2ee57a6c4fdedf7268a5c20cc89f"
+           revision="6574ca1b6112e912dcb2ec474056d101797187d3"
            name="Pelagicore/meta-pelux-bsp-intel"
            path="sources/meta-pelux-bsp-intel" />
 


### PR DESCRIPTION
When updating the git hash in one of the pelux-intel-* manifests the other
needs to be updated as well.

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>