### PR TITLE
pelux distro: update bistro, PELUX and BSP layers

### DIFF
--- a/pelux-base.xml
+++ b/pelux-base.xml
@@ -22,7 +22,7 @@
            path="sources/poky"/>
 
   <project remote="github"
-           revision="74f68eeee4f329cc97bb57ed3fccf28e7839ce81"
+           revision="37602f52e6a4353135ddcdc5584b6bd09bc38618"
            name="Pelagicore/meta-bistro"
            path="sources/meta-bistro" />
 
@@ -32,7 +32,7 @@
            path="sources/meta-virtualization"/>
 
   <project remote="github"
-           revision="3f8504bb24c0727cb32bf5ca698f27d3e4510165"
+           revision="f70db946bf59f7d81dd0b5cec9adf0f19366f06e"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux" />
 

--- a/pelux-intel-qt.xml
+++ b/pelux-intel-qt.xml
@@ -9,7 +9,7 @@
   <remove-project name="Pelagicore/meta-pelux-bsp-intel" />
   <project name="Pelagicore/meta-pelux-bsp-intel"
            remote="github"
-           revision="446b786366a2ae34bd2abe345ef0c89f2f7be023"
+           revision="c2efd3a90dd5d8bfae023dc081eb5f6f0650e82b"
            path="sources/meta-pelux-bsp-intel">
 
       <copyfile src="conf-qt/bblayers.conf.sample"

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -11,7 +11,7 @@
 
   <!-- When updating this, also update pelux-intel-qt.xml -->
   <project remote="github"
-           revision="446b786366a2ae34bd2abe345ef0c89f2f7be023"
+           revision="c2efd3a90dd5d8bfae023dc081eb5f6f0650e82b"
            name="Pelagicore/meta-pelux-bsp-intel"
            path="sources/meta-pelux-bsp-intel" />
 

--- a/pelux-rpi.xml
+++ b/pelux-rpi.xml
@@ -10,7 +10,7 @@
            path="sources/meta-raspberrypi"/>
 
   <project remote="github"
-           revision="225904ef2c9b1a8d12bf8845ee4f45d4c8e62e00"
+           revision="203c0844aa68e46f46162d1a99cbe7c513d5fbd6"
            name="Pelagicore/meta-pelux-bsp-rpi"
            path="sources/meta-pelux-bsp-rpi" />
 


### PR DESCRIPTION
This introduces PELUX as a Yocto distribution. The distribution conf file
as well as the image files can be found in the meta-pelux layer. Distro
and image configuration has been moved from the BSP meta layers
local.conf files to the meta-pelux layer. The meta-bistro layer is used
as an aggregate of Pelagicore components and bbappends.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>