### PR TITLE
Rename core-image-pelux-qt to core-image-pelux-qtauto

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,5 +63,5 @@ def buildManifest = {String manifest, String bitbake_image ->
 parallel 'core':{
     node("DockerCI") { buildManifest("pelux-intel.xml", "core-image-pelux") }
 },'qtauto':{
-    node("DockerCI") { buildManifest("pelux-intel-qt.xml", "core-image-pelux-qt") }
+    node("DockerCI") { buildManifest("pelux-intel-qtauto.xml", "core-image-pelux-qtauto") }
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Building an Image
 The following manifests can be used for a build:
 
 * `pelux-intel.xml` - For building the `core-image-pelux` image for Intel
-* `pelux-intel-qt.xml` - For building the `core-image-pelux-qt` image, which is the baseline with QtAS
+* `pelux-intel-qtauto.xml` - For building the `core-image-pelux-qtauto` image, which is the baseline with Qt Automotive Suite
 * `pelux-rpi.xml` - For building the `core-image-pelux`image for Raspberry Pi 3
 
 An image build can be started using a container/virtual machine, see section
@@ -25,7 +25,7 @@ continuous integration jobs.
 Variables:
 
 * Manifest, refers to what `<manifest-name>.xml` file you want to use, for example `pelux-intel.xml`. Each hardware platform targeted by the PELUX reference has its own manifest describing what other git repositories are needed for the build.
-* Image, refers to what version of PELUX that should be built. Currently there are two versions: `core-image-pelux` and `core-image-pelux-qt`. The latter being a version that includes NeptuneUI and QtApplicationManager.
+* Image, refers to what version of PELUX that should be built. Currently there are two versions: `core-image-pelux` and `core-image-pelux-qtauto`. The latter being a version that includes NeptuneUI and QtApplicationManager.
 
 ### Using vagrant
 

--- a/doc/manifest_structure.md
+++ b/doc/manifest_structure.md
@@ -22,7 +22,7 @@ In contrast to `Base` and `Qt` there are multiple instances of `BSP` and
 `BSP + QtAS`. However, each such instance holds mappings to git repositories
 required by specific hardware target. This means that there is no one `BSP`
 or `BSP + QtAS` manifest file, but one file each per hardware target. An example
-of this are `pelux-intel.xml` and `pelux-intel-qt.xml`this which represent
+of this are `pelux-intel.xml` and `pelux-intel-qtauto.xml` which represent
 specific implementations of `BSP` and `BSP + QtAS` for the intel hardware target.
 
 Using this structure, a minimal number of manifest files needs to be created in

--- a/pelux-base.xml
+++ b/pelux-base.xml
@@ -32,7 +32,7 @@
            path="sources/meta-virtualization"/>
 
   <project remote="github"
-           revision="f70db946bf59f7d81dd0b5cec9adf0f19366f06e"
+           revision="c98f573aefe4e80ccdebaf70e061e1e976cbdbaf"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux" />
 

--- a/pelux-intel-qtauto.xml
+++ b/pelux-intel-qtauto.xml
@@ -9,7 +9,7 @@
   <remove-project name="Pelagicore/meta-pelux-bsp-intel" />
   <project name="Pelagicore/meta-pelux-bsp-intel"
            remote="github"
-           revision="c2efd3a90dd5d8bfae023dc081eb5f6f0650e82b"
+           revision="bc8064d0ca34b45ef22d4951bf066a7541bd708d"
            path="sources/meta-pelux-bsp-intel">
 
       <copyfile src="conf-qt/bblayers.conf.sample"

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -9,9 +9,9 @@
            name="meta-intel"
            path="sources/meta-intel"/>
 
-  <!-- When updating this, also update pelux-intel-qt.xml -->
+  <!-- When updating this, also update pelux-intel-qtauto.xml -->
   <project remote="github"
-           revision="c2efd3a90dd5d8bfae023dc081eb5f6f0650e82b"
+           revision="bc8064d0ca34b45ef22d4951bf066a7541bd708d"
            name="Pelagicore/meta-pelux-bsp-intel"
            path="sources/meta-pelux-bsp-intel" />
 


### PR DESCRIPTION
This was done in order to explicitly reflect that the qtauto image adds
Qt Automotive Suite components.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>