### PR TITLE
Use ARCHIVE_CACHE env variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,9 @@ def buildManifest = {String manifest, String bitbake_image ->
         sh "mkdir -p archive"
         sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/tmp/deploy/images/ /vagrant/archive/\""
 
-        // Archive the downloads and sstate when we build the master
-        if (env.BRANCH_NAME == "master") {
+        // Archive the downloads and sstate when the environment variable was set to true
+        // by the Jenkins job.
+        if (env.ARCHIVE_CACHE) {
             sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/downloads/ /vagrant/archive/\""
             sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/sstate-cache/ /vagrant/archive/\""
         }


### PR DESCRIPTION
Most of the time we don't need to archive the sstate and download
cache. For the moments we do, this patch offers a environment variable
which one can set via a parameterized Jenkins job.

Mostly this would be used by the nightly jobs to freshen up the
shared caches.