### PR TITLE
pelux-intel-qtauto.xml: copy qt-specific notes

### DIFF
--- a/pelux-intel-qtauto.xml
+++ b/pelux-intel-qtauto.xml
@@ -9,13 +9,15 @@
   <remove-project name="Pelagicore/meta-pelux-bsp-intel" />
   <project name="Pelagicore/meta-pelux-bsp-intel"
            remote="github"
-           revision="570715f36d27e1da310f9b8a4b9e7f4e9ad0eb56"
+           revision="cc6cc05a4bbe9a7154f21b1d23c59c097adbb5fa"
            path="sources/meta-pelux-bsp-intel">
 
       <copyfile src="conf-qt/bblayers.conf.sample"
                 dest="sources/meta-pelux-bsp-intel/conf/bblayers.conf.sample" />
       <copyfile src="conf-qt/local.conf.sample"
                 dest="sources/meta-pelux-bsp-intel/conf/local.conf.sample" />
+      <copyfile src="conf-qt/conf-notes.txt"
+                dest="sources/meta-pelux-bsp-intel/conf/conf-notes.txt" />
   </project>
 
 </manifest>

--- a/pelux-intel.xml
+++ b/pelux-intel.xml
@@ -11,7 +11,7 @@
 
   <!-- When updating this, also update pelux-intel-qtauto.xml -->
   <project remote="github"
-           revision="570715f36d27e1da310f9b8a4b9e7f4e9ad0eb56"
+           revision="cc6cc05a4bbe9a7154f21b1d23c59c097adbb5fa"
            name="Pelagicore/meta-pelux-bsp-intel"
            path="sources/meta-pelux-bsp-intel" />
 


### PR DESCRIPTION
The notes currently contain info on what images are available, and when
using qtauto (meaning using b2qt), more images are available than when
building without qtauto.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>