### PR TITLE
Revert "Jenkinsfile: remove archiving of artifacts."

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,15 @@ def buildManifest = {String manifest, String bitbake_image ->
         sh "vagrant ssh -c \"/vagrant/vagrant-cookbook/yocto/build-images.sh ${yoctoDir} ${bitbake_image}\""
     }
 
+    stage("Copy downloads and cache ${bitbake_image}") {
+        // Archive the downloads and sstate when the environment variable was set to true
+        // by the Jenkins job.
+        if (env.ARCHIVE_CACHE) {
+            sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/downloads/ /vagrant/archive/\""
+            sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/sstate-cache/ /vagrant/archive/\""
+        }
+    }
+
     // Always try to shut down the machine
     // Shutdown the machine
     sh "vagrant destroy -f || true"


### PR DESCRIPTION
This reverts commit c0165129f68d86444ffe66865e70f025cff0e36a.

We still save the cache, but we don't publish any artifacts.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>