### PR TITLE
Jenkinsfile: use NFS-setup for yocto-cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,12 @@ def buildManifest = {String bitbake_image, String bsp, boolean qtauto ->
     // Store the directory we are executed in as our workspace.
     String workspace = pwd()
 
+    // These could be empty, so check for that when using them.
+    environment {
+        YOCTO_CACHE_URL = "${env.YOCTO_CACHE_URL}"
+        YOCTO_CACHE_ARCHIVE_PATH = "${env.YOCTO_CACHE_ARCHIVE_PATH}"
+    }
+
     // Stages are subtasks that will be shown as subsections of the finished build in Jenkins.
 
     stage("Checkout ${bitbake_image}") {
@@ -55,9 +61,9 @@ def buildManifest = {String bitbake_image, String bsp, boolean qtauto ->
     stage("Copy downloads and cache ${bitbake_image}") {
         // Archive the downloads and sstate when the environment variable was set to true
         // by the Jenkins job.
-        if (env.ARCHIVE_CACHE) {
-            sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/downloads/ /vagrant/archive/\""
-            sh "vagrant ssh -c \"cp -a ${yoctoDir}/build/sstate-cache/ /vagrant/archive/\""
+        if (env.ARCHIVE_CACHE && env.YOCTO_CACHE_ARCHIVE_PATH?.trim()) {
+            sh "vagrant ssh -c \"rsync -trpg ${yoctoDir}/build/downloads/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/downloads/\""
+            sh "vagrant ssh -c \"rsync -trpg ${yoctoDir}/build/sstate-cache/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/sstate-cache\""
         }
     }
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,12 @@ Vagrant.configure(2) do |config|
         configOverride.vm.box = "debian/jessie64"
     end
 
+    # If an archive path for the yocto cache is given, we mount it into the vm
+    # using the same path as on the host.
+    unless ENV['YOCTO_CACHE_ARCHIVE_PATH'].to_s.strip.empty?
+        config.vm.synced_folder ENV['YOCTO_CACHE_ARCHIVE_PATH'], ENV['YOCTO_CACHE_ARCHIVE_PATH']
+    end
+
 
     # On some hosts, the network stack needs to be kicked alive
     config.vm.provision "shell", privileged: false, inline: <<-SHELL


### PR DESCRIPTION
Instead of copying to /vagrant/archive and then depend on another job to
publish the cache, we assume /var/yocto-cache is a NFS share to which we
can write (and read from). The share should be shared with any build
slave we have.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>