### PR TITLE
Add --no-cache to docker build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,16 @@ FROM ubuntu:16.04
 ARG userid=1000
 
 RUN mkdir /var/run/sshd
-RUN apt-get update
-RUN apt-get install -y openssh-server sudo
 
-# Required by bitbake
-RUN apt-get install -y cpio iputils-ping
-
+# Install dependencies in one command to avoid potential use of previous cache
+# like explained here: https://stackoverflow.com/a/37727984
+RUN apt-get update \
+    && apt-get install -y openssh-server sudo cpio inetutils-ping locales
+    
+RUN rm -rf /var/lib/apt/lists/*
+    
 # en_US.utf8 is required by Yocto sanity check
-RUN apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 RUN useradd --uid $userid vagrant --create-home --user-group --groups sudo
@@ -21,4 +22,3 @@ RUN echo 'vagrant ALL=(ALL) NOPASSWD:SETENV: ALL' > /etc/sudoers.d/vagrant
 
 EXPOSE 22
 CMD  ["/usr/sbin/sshd", "-D"]
-


### PR DESCRIPTION
According to https://stackoverflow.com/a/37727984

Our Dockerfile contains RUN apt-get -y update as its own RUN
instruction. However, due to build caching, if all changes to
the Dockerfile occur later in the file, when docker build is
run, Docker will reuse the intermediate image created the
last time RUN apt-get -y update executed instead of running
the command again, and so any recently-added or -edited
apt-get install lines will be using old data, leading to the
errors you've observed.

The way to fix this:

Rewrite the Dockerfile to combine the apt-get commands in a
single RUN instruction: RUN apt-get update && apt-get install
foo bar .... This way, whenever the list of packages to
install is edited, docker build will be forced to re-execute
the entire RUN instruction and thus rerun apt-get update
before installing.