### PR TITLE
Vagrant: Remove VirtualBox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ NeptuneUI and QtApplicationManager.
 
 ### Using vagrant
 
+Please note that we only run this setup in a GNU/Linux system at Pelagicore. It
+should still work under Windows or OSX, we haven't tried it.
+
 Dependencies:
 
 * Vagrant
-* Docker or VirtualBox
-* virtualization enabled in bios
+* Docker
+* Virtualization enabled in BIOS
 
 Procedure:
 
@@ -40,7 +43,7 @@ Procedure:
 2. Start vagrant
 
     ```bash
-    vagrant up --provider="docker"
+    vagrant up
     ```
 
 3. Set variables to be used below

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Path to extra disk
-disk_name = 'yocto_disk.vdi'
-disk_size_gb = 200
-
-# System resources
-ram = 16 #GB
-cpus = 6
-
 Vagrant.configure(2) do |config|
-
-    # Prefer docker over virtualbox since it is listed first
-    # meaning that docker should run if no '--provider' is supplied
-    # when calling vagrant up
     config.vm.provider "docker" do |d, configOverride|
         d.build_dir = "."
         d.pull = true
@@ -25,20 +13,11 @@ Vagrant.configure(2) do |config|
         configOverride.ssh.password = "vagrant"
     end
 
-    config.vm.provider "virtualbox" do |vb, configOverride|
-        vb.memory = ram * 1024
-        vb.cpus = cpus
-
-        # Overrides for 'configs' unique for virtualbox
-        configOverride.vm.box = "debian/jessie64"
-    end
-
     # If an archive path for the yocto cache is given, we mount it into the vm
     # using the same path as on the host.
     unless ENV['YOCTO_CACHE_ARCHIVE_PATH'].to_s.strip.empty?
         config.vm.synced_folder ENV['YOCTO_CACHE_ARCHIVE_PATH'], ENV['YOCTO_CACHE_ARCHIVE_PATH']
     end
-
 
     # On some hosts, the network stack needs to be kicked alive
     config.vm.provision "shell", privileged: false, inline: <<-SHELL


### PR DESCRIPTION
We prefer using Docker for builds (faster + lighter) and haven't used
VBox for a while in the CI.

Closes #64 

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>