### PR TITLE
WIP: Jenkinsfile: sync CACHE over SSH instead of NFS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,9 @@ def buildManifest = {String variant_name, boolean bitbake_image ->
             // Archive the downloads and sstate when the environment variable was set to true
             // by the Jenkins job.
             if (env.ARCHIVE_CACHE && env.YOCTO_CACHE_ARCHIVE_PATH?.trim()) {
-                vagrant("rsync -trpg ${yoctoDir}/build/downloads/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/downloads/")
-                vagrant("rsync -trpg ${yoctoDir}/build/sstate-cache/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/sstate-cache")
+                String targetPrefix = "${env.YOCTO_CACHE_SSH_HOST}:${env.YOCTO_CACHE_ARCHIVE_PATH}"
+                sh "rsync -trpge ssh ${yoctoDir}/build/downloads/ ${targetPrefix}/downloads/"
+                sh "rsync -trpge ssh ${yoctoDir}/build/sstate-cache/ ${targetPrefix}/sstate-cache"
             }
         }
 


### PR DESCRIPTION
We still read the cache over NFS, but with SSH to write we don't need
uids to match, which means more possible freedom in for example the
Dockerfile.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>