### PR TITLE
pelux.xml: Add meta-swupdate

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -41,6 +41,12 @@
            name="meta-virtualization"
            path="sources/meta-virtualization"/>
 
+  <project remote="github"
+           revision="00ff53a574bf03bed29d80945f5e589879d3e2b2"
+           upstream="rocko"
+           name="sbabic/meta-swupdate"
+           path="sources/meta-swupdate" />
+
   <!-- GENIVI stuff, update the upstream from master to 14.0 when possible-->
   <project remote="github"
            upstream="master"


### PR DESCRIPTION
In order to integrate swupdate to PELUX, this PR downloads meta-pelux into the sources/ directory.

This PR is written for pyro. If https://github.com/Pelagicore/pelux-manifests/pull/112 is merged before, I will update the current commit hash and branch label to point to the rocko branch of meta-swupdate.