### PR TITLE
Jenkinsfile: set rm_work in local.conf for yocto

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,9 @@ void buildManifest(String variant_name, String bitbake_image) {
             if (env.YOCTO_CACHE_URL?.trim()) {
                 vagrant("sed 's|%CACHEURL%|${env.YOCTO_CACHE_URL}|g' /vagrant/site.conf.in > ${yoctoDir}/build/conf/site.conf")
             }
+
+            // Add other settings that are CI specific to the local.conf
+            vagrant("cat /vagrant/local.conf.appendix >> ${yoctoDir}/build/conf/local.conf")
         }
 
         stage("Fetchall ${variant_name}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // Copyright (C) Pelagicore AB 2017
 
 // Helper function to run commands through vagrant
-def vagrant = {String command ->
+void vagrant(String command) {
     sh "vagrant ssh -c \"${command}\""
 }
 
@@ -11,7 +11,7 @@ def vagrant = {String command ->
  * Supported values for bsp are "intel" or "rpi"
  * Supported values for qtauto are true or false
  */
-def buildManifest = {String variant_name, boolean bitbake_image ->
+void buildManifest(String variant_name, String bitbake_image) {
     // Store the directory we are executed in as our workspace.
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"

--- a/local.conf.appendix
+++ b/local.conf.appendix
@@ -1,0 +1,3 @@
+
+# Settings that we want in the CI environment
+INHERIT += "rm_work"


### PR DESCRIPTION
To avoid having too large yocto builds, we let yocto remove work
material from the build once it is no longer needed.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>