### PR TITLE
Revert "Dockerfile: bump FROM to Ubuntu 17.10"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crops/yocto:ubuntu-17.10-base
+FROM crops/yocto:ubuntu-16.04-base
 
 LABEL description="PELUX Yocto build environment"
 LABEL maintainer="tobias.olausson@pelagicore.com"


### PR DESCRIPTION
The revert caused building qtbase-native to fail, probably too new
compiler or python or something. Let's just keep it at 16.04 for now.

This reverts commit 99a00eb09fa5347cd2467a45b740be7a98402673.