### PR TITLE
Jenkinsfile: use "Yocto" as label for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ void buildManifest(String variant_name, String bitbake_image) {
     String manifest = "pelux.xml"
 
     // Everything we run here runs in a docker container handled by Vagrant
-    node("DockerCI") {
+    node("Yocto") {
 
         // These could be empty, so check for that when using them.
         environment {


### PR DESCRIPTION
When moving to building more things than just the images with Docker,
the DockerCI label makes little sense to rely on. Rather, it can be used
with any Docker based build, but we still want the yocto builds to be
tied to specific (powerful) slaves.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>