### PR TITLE
Break out groovy code from Jenkinsfile to facilitate reuse

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,31 +2,42 @@
 
 // Copyright (C) Luxoft Sweden AB 2018
 
-def manifests = load "ci-scripts/yocto.groovy"
-
 // Run the different variants in parallel, on different slaves (if possible)
+
+// We could do a single "checkout scm" and load the groovy script, but to do
+// that one has to allocate a node first, which would stay busy until the end of
+// the parallel pipeline
 parallel (
     'intel': {
         node("Yocto") {
+            checkout scm
+            def manifests = load "ci-scripts/yocto.groovy"
             manifests.buildManifest("intel", "core-image-pelux-minimal")
         }
     },
 
     'intel-qtauto': {
         node("Yocto") {
+            checkout scm
+            def manifests = load "ci-scripts/yocto.groovy"
             manifests.buildManifest("intel-qtauto", "core-image-pelux-qtauto-neptune")
         }
     },
 
     'rpi': {
         node("Yocto") {
+            checkout scm
+            def manifests = load "ci-scripts/yocto.groovy"
             manifests.buildManifest("rpi", "core-image-pelux-minimal")
         }
     },
 
     'rpi-qtauto': {
         node("Yocto") {
+            checkout scm
+            def manifests = load "ci-scripts/yocto.groovy"
             manifests.buildManifest("rpi-qtauto", "core-image-pelux-qtauto-neptune")
         }
     }
 )
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,117 +1,32 @@
 #!/usr/bin/groovy
 
-// Copyright (C) Pelagicore AB 2017
+// Copyright (C) Luxoft Sweden AB 2018
 
-// Helper function to run commands through vagrant
-void vagrant(String command) {
-    sh "vagrant ssh -c \"${command}\""
-}
-
-/*
- * Supported values for bsp are "intel" or "rpi"
- * Supported values for qtauto are true or false
- */
-void buildManifest(String variant_name, String bitbake_image) {
-    // Store the directory we are executed in as our workspace.
-    String yoctoDir = "/home/yoctouser/pelux_yocto"
-    String manifest = "pelux.xml"
-
-    // Everything we run here runs in a docker container handled by Vagrant
-    node("Yocto") {
-
-        // Stages are subtasks that will be shown as subsections of the finished
-        // build in Jenkins.
-        try {
-
-            stage("Checkout ${variant_name}") {
-                // Checkout the git repository and refspec pointed to by jenkins
-                checkout scm
-                // Update the submodules in the repository.
-                sh 'git submodule update --init'
-            }
-
-            stage("Start Vagrant ${variant_name}") {
-                // Start the machine (destroy it if present) and provision it
-                sh "vagrant destroy -f || true"
-                sh "vagrant up"
-            }
-
-            stage("Repo init ${variant_name}") {
-                vagrant("/vagrant/ci-scripts/do_repo_init ${manifest}")
-            }
-
-            stage("Setup bitbake ${variant_name}") {
-                // Setup bitbake environment
-                templateconf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
-                vagrant("/vagrant/cookbook/yocto/initialize-bitbake.sh ${yoctoDir} ${templateconf}")
-
-                // Setup site.conf if not building the master to do a incremental build.
-                // The YOCTO_CACHE_URL can be set globally in Manage Jenkins -> Configure System -> Global Properties
-                // or for one job as a parameter.
-                if (env.YOCTO_CACHE_URL && env.YOCTO_CACHE_URL?.trim()) {
-                    vagrant("sed 's|%CACHEURL%|${env.YOCTO_CACHE_URL}|g' /vagrant/site.conf.in > ${yoctoDir}/build/conf/site.conf")
-                }
-
-                // Add other settings that are CI specific to the local.conf
-                vagrant("cat /vagrant/local.conf.appendix >> ${yoctoDir}/build/conf/local.conf")
-            }
-
-            stage("Fetchall ${variant_name}") {
-                // Without cache access, we do want to do fetchall, but only then.
-                if (!env.YOCTO_CACHE_URL) {
-                    vagrant("/vagrant/cookbook/yocto/fetch-sources-for-recipes.sh ${yoctoDir} ${bitbake_image}")
-                }
-            }
-
-            try {
-
-                stage("Bitbake ${variant_name}") {
-                    vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${bitbake_image}")
-                    vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${bitbake_image}-dev")
-                }
-
-                stage("Build SDK ${variant_name}") {
-                    vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${bitbake_image}")
-                    vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${bitbake_image}-dev")
-                }
-            } finally { // Archive cache even if there were errors.
-                stage("Archive cache ${variant_name}") {
-                    // Archive the downloads and sstate when the environment variable was set to true
-                    // by the Jenkins job.
-                    if (env.ARCHIVE_CACHE && env.YOCTO_CACHE_ARCHIVE_PATH?.trim()) {
-                        vagrant("rsync -trpg ${yoctoDir}/build/downloads/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/downloads/")
-                        vagrant("rsync -trpg ${yoctoDir}/build/sstate-cache/ ${env.YOCTO_CACHE_ARCHIVE_PATH}/sstate-cache")
-                    }
-                }
-
-                if (env.NIGHTLY_BUILD?.trim()) {
-                    stage("Archive artifacts ${variant_name}") {
-                        String artifactDir = "artifacts_${variant_name}"
-
-                        sh "rm -rf ${artifactDir}"
-                        sh "mkdir ${artifactDir}"
-
-                        // Copy images and SDK to the synced directory
-                        vagrant("/vagrant/ci-scripts/copy_to_archive ${yoctoDir}/build /vagrant/${artifactDir}")
-
-                        // And save them in Jenkins
-                        archiveArtifacts "${artifactDir}/**"
-                    }
-                }
-            }
-        } finally {
-            retry(5) {
-                // Always try to shut down the machine
-                sh "vagrant destroy -f"
-            }
-        }
-    }
-}
+def manifests = load "ci-scripts/yocto.groovy"
 
 // Run the different variants in parallel, on different slaves (if possible)
 parallel (
-    'intel':        { buildManifest("intel",        "core-image-pelux-minimal") },
-    'intel-qtauto': { buildManifest("intel-qtauto", "core-image-pelux-qtauto-neptune") },
-    'rpi':          { buildManifest("rpi",          "core-image-pelux-minimal") },
-    'rpi-qtauto':   { buildManifest("rpi-qtauto",   "core-image-pelux-qtauto-neptune") }
+    'intel': {
+        node("Yocto") {
+            manifests.buildManifest("intel", "core-image-pelux-minimal")
+        }
+    },
+
+    'intel-qtauto': {
+        node("Yocto") {
+            manifests.buildManifest("intel-qtauto", "core-image-pelux-qtauto-neptune")
+        }
+    },
+
+    'rpi': {
+        node("Yocto") {
+            manifests.buildManifest("rpi", "core-image-pelux-minimal")
+        }
+    },
+
+    'rpi-qtauto': {
+        node("Yocto") {
+            manifests.buildManifest("rpi-qtauto", "core-image-pelux-qtauto-neptune")
+        }
+    }
 )

--- a/ci-scripts/do_repo_init
+++ b/ci-scripts/do_repo_init
@@ -27,7 +27,7 @@ if [ "${MANIFEST}" = "" ]; then
 fi
 
 # Parameter expansion with default values
-SYNC_DIR="${2:-$(pwd)}"
+SYNC_DIR="${2:-/vagrant}"
 YOCTO_DIR="${3:-pelux_yocto}"
 
 echo "Running repo init with the following settings:"
@@ -42,7 +42,6 @@ echo "yocto dir=${YOCTO_DIR}"
 # host already fetched the correct refs via the Jenkinsfile.
 
 # Copy the host repo to ensure that no later git commands destroy anything.
-SYNC_DIR="/vagrant"
 COPY_DIR="/tmp/git_repo"
 cp -r ${SYNC_DIR} ${COPY_DIR}
 

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -111,7 +111,7 @@ void archiveArtifacts(String yoctoDir, String suffix) {
     }
 }
 
-void buildElsewhere(String variant_name, String bitbake_image, manifestFun = { }) {
+void buildWithLayer(String variant_name, String bitbake_image, String layer, String layerPath) {
     // Store the directory we are executed in as our workspace.
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
@@ -124,7 +124,7 @@ void buildElsewhere(String variant_name, String bitbake_image, manifestFun = { }
         startVagrant()
         repoInit(manifest)
 
-        manifestFun()
+        replaceLayer(yoctoDir, layer, layerPath)
 
         // Setup yocto
         templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
@@ -163,8 +163,6 @@ void buildManifest(String variant_name, String bitbake_image) {
         // Initialize vagrant and repo manifest
         startVagrant()
         repoInit(manifest)
-
-        manifestFun()
 
         // Setup yocto
         templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -1,0 +1,189 @@
+#!/usr/bin/groovy
+
+// Copyright (C) Luxoft Sweden AB 2018
+
+// Helper function to run commands through vagrant
+int vagrant(String command, boolean saveStatus=false) {
+    sh returnStatus: saveStatus, script: "vagrant ssh -c \"${command}\""
+}
+
+// Helper to do checkout and update submodules
+void checkoutWithSubmodules() {
+    // Checkout the git repository and refspec pointed to by jenkins
+    stage("Checkout") {
+        checkout scm
+        sh "git submodule update --init"
+    }
+}
+
+// Start the machine (destroy it if present) and provision it
+void startVagrant(boolean kill=true) {
+    stage("Start vagrant") {
+        if (kill) {
+            shutdownVagrant()
+        }
+
+        sh "vagrant up"
+    }
+}
+
+void shutdownVagrant() {
+    stage("Shutdown vagrant") {
+        retry(5) {
+            sh "vagrant destroy -f"
+        }
+    }
+}
+
+void repoInit(String manifest) {
+    stage("Repo init") {
+        vagrant("/vagrant/ci-scripts/do_repo_init ${manifest}")
+    }
+}
+
+void setupBitbake(String yoctoDir, String templateConf) {
+    stage("Setup bitbake") {
+        vagrant("/vagrant/cookbook/yocto/initialize-bitbake.sh ${yoctoDir} ${templateConf}")
+
+        // Add other settings that are CI specific to the local.conf
+        vagrant("cat /vagrant/local.conf.appendix >> ${yoctoDir}/build/conf/local.conf")
+    }
+}
+
+void setupCache(String yoctoDir, String url) {
+    stage("Setup cache") {
+        // Setup site.conf if not building the master to do a incremental build.
+        // The YOCTO_CACHE_URL can be set globally in Manage Jenkins -> Configure System -> Global Properties
+        // or for one job as a parameter.
+        if (url?.trim()) {
+            vagrant("sed 's|%CACHEURL%|${url}|g' /vagrant/site.conf.in > ${yoctoDir}/build/conf/site.conf")
+        } else {
+            echo "No cache setup"
+        }
+    }
+}
+
+void buildImageAndSDK(String yoctoDir, String imageName, boolean dev=true) {
+    // If we have a site.conf, that means we have caching, if we don't that
+    // means we should do a fetchall.
+    if (vagrant("test -f ${yoctoDir}/build/conf/site.conf", true) != 0) {
+        stage("Fetch sources") {
+            vagrant("/vagrant/cookbook/yocto/fetch-sources-for-recipes.sh ${yoctoDir} ${bitbake_image}")
+        }
+    }
+
+    stage("Bitbake ${imageName}") {
+        vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}")
+        if (dev) {
+            vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}-dev")
+        }
+    }
+
+    stage("Build SDK ${imageName}") {
+        vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${imageName}")
+        if (dev) {
+            vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${imageName}-dev")
+        }
+    }
+}
+
+void archiveCache(String yoctoDir, boolean archive, String archivePath) {
+    if (archive) {
+        stage("Archive cache") {
+            vagrant("rsync -trpg ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
+            vagrant("rsync -trpg ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
+        }
+    }
+}
+
+void archiveArtifacts(String yoctoDir, String suffix) {
+    stage("Archive artifacts") {
+        String artifactDir = "artifacts_${suffix}"
+
+        sh "rm -rf ${artifactDir}"
+        sh "mkdir ${artifactDir}"
+
+        // Copy images and SDK to the synced directory
+        vagrant("/vagrant/ci-scripts/copy_to_archive ${yoctoDir}/build /vagrant/${artifactDir}")
+
+        // And save them in Jenkins
+        archiveArtifacts "${artifactDir}/**"
+    }
+}
+
+void buildElsewhere(String variant_name, String bitbake_image, manifestFun = { }) {
+    // Store the directory we are executed in as our workspace.
+    String yoctoDir = "/home/yoctouser/pelux_yocto"
+    String manifest = "pelux.xml"
+
+    // We can't do "checkout scm" here since pelux-manifests is not the
+    // canonical repo here.
+    sh "git submodule update --init"
+    try {
+        // Initialize vagrant and repo manifest
+        startVagrant()
+        repoInit(manifest)
+
+        manifestFun()
+
+        // Setup yocto
+        templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
+        setupBitbake(yoctoDir, templateConf)
+        setupCache(yoctoDir, env.YOCTO_CACHE_URL)
+
+        // Build the images
+        try {
+            buildImageAndSDK(yoctoDir, bitbake_image)
+        } finally { // Archive cache even if there were errors.
+            archiveCache(yoctoDir, env.ARCHIVE_CACHE, env.YOCTO_CACHE_ARCHIVE_PATH)
+
+            if (env.NIGHTLY_BUILD) {
+                archiveArtifacts(yoctoDir, variant_name)
+            }
+        }
+    } finally {
+        shutdownVagrant()
+    }
+}
+
+void replaceLayer(String yoctoDir, String layerName, String newPath) {
+    vagrant("rm -rf ${yoctoDir}/sources/${layerName}")
+    sh "cp -R ${newPath} ${layerName}"
+    vagrant("mv /vagrant/${layerName} ${yoctoDir}/sources/")
+}
+
+void buildManifest(String variant_name, String bitbake_image) {
+    // Store the directory we are executed in as our workspace.
+    String yoctoDir = "/home/yoctouser/pelux_yocto"
+    String manifest = "pelux.xml"
+
+    // Initialize code
+    checkoutWithSubmodules()
+    try {
+        // Initialize vagrant and repo manifest
+        startVagrant()
+        repoInit(manifest)
+
+        manifestFun()
+
+        // Setup yocto
+        templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
+        setupBitbake(yoctoDir, templateConf)
+        setupCache(yoctoDir, env.YOCTO_CACHE_URL)
+
+        // Build the images
+        try {
+            buildImageAndSDK(yoctoDir, bitbake_image)
+        } finally { // Archive cache even if there were errors.
+            archiveCache(yoctoDir, env.ARCHIVE_CACHE, env.YOCTO_CACHE_ARCHIVE_PATH)
+
+            if (env.NIGHTLY_BUILD) {
+                archiveArtifacts(yoctoDir, variant_name)
+            }
+        }
+    } finally {
+        shutdownVagrant()
+    }
+}
+
+return this;

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -127,7 +127,7 @@ void buildWithLayer(String variant_name, String bitbake_image, String layer, Str
         replaceLayer(yoctoDir, layer, layerPath)
 
         // Setup yocto
-        templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
+        String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
         setupBitbake(yoctoDir, templateConf)
         setupCache(yoctoDir, env.YOCTO_CACHE_URL)
 
@@ -165,7 +165,7 @@ void buildManifest(String variant_name, String bitbake_image) {
         repoInit(manifest)
 
         // Setup yocto
-        templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
+        String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variant_name}"
         setupBitbake(yoctoDir, templateConf)
         setupCache(yoctoDir, env.YOCTO_CACHE_URL)
 


### PR DESCRIPTION
As seen, the Jenkinsfile is now a "load" directive and calling a function on the loaded file object. A similar pattern will be used to build pelux-manifests from pull requests on meta-pelux, meta-bistro and meta-template (but these will have to clone this repo first).

Example (unfinished) for meta-pelux: https://github.com/Pelagicore/meta-pelux/pull/106/files