### PR TITLE
Remove Dockerfile maintainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM crops/yocto:ubuntu-16.04-base
 
 LABEL description="PELUX Yocto build environment"
-LABEL maintainer="tobias.olausson@pelagicore.com"
 
 # Enables us to overwrite the user ID for the yoctouser. See below
 ARG userid=1000


### PR DESCRIPTION
We have maintenance for the whole repo, no need for special maintainers
for the Dockerfile.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>