### PR TITLE
ci-scripts/do_repo_init: suppress error message

### DIFF
--- a/ci-scripts/do_repo_init
+++ b/ci-scripts/do_repo_init
@@ -51,7 +51,7 @@ cp -r ${SYNC_DIR} ${COPY_DIR}
 
 # Make sure there is a master branch and that it is pointing to the latest commit.
 cd ${COPY_DIR}
-git branch -D master || true
+git branch -D master 2> /dev/null || true
 git checkout -b master
 cd -
 


### PR DESCRIPTION
The error from deleting a branch that doesn't exist is safe, but the
error show up in logs which is annoying when looking for true errors.