### PR TITLE
CI: add missing smoke test flag in yocto.groovy

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -41,7 +41,7 @@ void repoInit(String manifest) {
     }
 }
 
-void setupBitbake(String yoctoDir, String templateConf, boolean smokeTests) {
+void setupBitbake(String yoctoDir, String templateConf, boolean smokeTests=false) {
     stage("Setup bitbake") {
         vagrant("/vagrant/cookbook/yocto/initialize-bitbake.sh ${yoctoDir} ${templateConf}")
 


### PR DESCRIPTION
The smokeTests flag did not have a default which caused errors
when using buildWithLayer.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>