### PR TITLE
ci-scripts/do_repo_init: check if master branch exists

### DIFF
--- a/ci-scripts/do_repo_init
+++ b/ci-scripts/do_repo_init
@@ -51,7 +51,13 @@ cp -r ${SYNC_DIR} ${COPY_DIR}
 
 # Make sure there is a master branch and that it is pointing to the latest commit.
 cd ${COPY_DIR}
-git branch -D master || true
+
+# Check if master branch exists
+git rev-parse --verify master
+if [$? == 0]; then
+    git branch -D master
+fi
+
 git checkout -b master
 cd -
 


### PR DESCRIPTION
Check if `master` branch exists before deleting it, otherwise it will
throw the following error flooding the log:

[intel] error: branch 'master' not found.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>