### PR TITLE
local.conf.appendix: limit threads

### DIFF
--- a/local.conf.appendix
+++ b/local.conf.appendix
@@ -1,2 +1,5 @@
 # Settings that we want in the CI environment
 INHERIT += "rm_work"
+
+PARALLEL_MAKE = "-j 2"
+BB_NUMBER_THREADS = "2"


### PR DESCRIPTION
Due to instability of builds on our local CI/CD, we temporarily limit
PARALLEL_MAKE and BB_NUMBER_THREADS to 2 per build.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>