### PR TITLE
site.conf.in:fix cache

### DIFF
--- a/site.conf.in
+++ b/site.conf.in
@@ -1,3 +1,3 @@
 INHERIT += "own-mirrors"
-SOURCE_MIRROR_URL ?= "%CACHEURL%/downloads/"
+SOURCE_MIRROR_URL ?= "file://%CACHEURL%/downloads/"
 SSTATE_MIRRORS ?= "file://.* %CACHEURL%/sstate-cache/PATH"


### PR DESCRIPTION
the file:// added is a protocol that looks for files locally.
Previously when u wanted to build with cache you had to use "file:///var/yocto-cache" now you only type: "/var/yocto-cache" 

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>