### PR TITLE
Add rsync flags to fix sync errors when building yocto cache

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -134,8 +134,8 @@ void runSmokeTests(String yoctoDir, String imageName) {
 void archiveCache(String yoctoDir, boolean archive, String archivePath) {
     if (archive && archivePath?.trim()) {
         stage("Archive cache") {
-            vagrant("rsync -trpg ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
-            vagrant("rsync -trpg ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
+            vagrant("rsync -trpgOl ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
+            vagrant("rsync -trpgOl ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
         }
     }
 }


### PR DESCRIPTION
Added rsync flags,
-O : Omit directories from preserving modification times
-l : Copy symlinks as symlinks

Without these flags, rsync was skipping syncing symlinks and
failing to preserve original times on directories that were
sync-ed.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>