### PR TITLE
yocto.groovy: run smoke-tests on dev image

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -116,7 +116,7 @@ void runSmokeTests(String yoctoDir, String imageName) {
 
     try {
         stage("Perform smoke testing") {
-            vagrant("/vagrant/cookbook/yocto/runqemu-smoke-test.sh ${yoctoDir} ${imageName}")
+            vagrant("/vagrant/cookbook/yocto/runqemu-smoke-test.sh ${yoctoDir} ${imageName}-dev")
         }
     } catch(e) {
         echo "There were failing tests"


### PR DESCRIPTION
The ssh test fails because ssh isn't enabled on non-dev images. 
Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>