### PR TITLE
pelux.xml: move meta-pelux back to sumo branch

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -30,7 +30,7 @@
            path="sources/meta-bistro" />
 
   <project remote="github"
-           revision="81eb9dbe7611f671155d32fb7a14105c0802454f"
+           revision="45d80155cbbf0b57561bf49b17957ce006f91792"
            upstream="sumo"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux" />


### PR DESCRIPTION
Accidentally moved to master in 24e24c8be10f07a2a33396e6124b46fabfd88539 .

Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>