### PR TITLE
Revert "pelux.xml: bump poky"

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="c942230eee405d35b99d85a3e9d8b00ce11d2222"
+           revision="45ef387cc54a0584807e05a952e1e4681ec4c664"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
This update causes issues with few packages. Let's fix them first.

This reverts commit 4d31dfa8da577be58c276f19f734e5d06a8fd2ec.