### PR TITLE
Revert "pelux.xml: bump poky"

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="c942230eee405d35b99d85a3e9d8b00ce11d2222"
+           revision="45ef387cc54a0584807e05a952e1e4681ec4c664"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
This caused some issues that are to be fixed first.

This reverts commit 53af4745c69248c4e9da06b3038622379aaef03f.