### PR TITLE
Fix intermittent IO errors in CI/CD by moving Yocto build dir to bind mount from overlay2 fs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM crops/yocto:ubuntu-16.04-base
 
 LABEL description="PELUX Yocto build environment"
 
-# Enables us to overwrite the user ID for the yoctouser. See below
+# Enables us to overwrite the user and group ID for the yoctouser. See below
 ARG userid=1000
+ARG groupid=1000
 
 USER root
 
@@ -46,9 +47,10 @@ RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN echo 'export LC_ALL="en_US.UTF-8"' >> /etc/profile
 ENV LANG en_US.utf8
 
-# Make sure the userID matches the UID given to Docker. This is so that mounted
+# Make sure the user/groupID matches the UID/GID given to Docker. This is so that mounted
 # dirs will get the correct permissions
 RUN usermod --uid $userid yoctouser
+RUN groupmod --gid $groupid yoctouser
 RUN echo 'yoctouser:yoctouser' | chpasswd
 RUN echo 'yoctouser ALL=(ALL) NOPASSWD:SETENV: ALL' > /etc/sudoers.d/yoctouser
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ void buildOnYoctoNode(String variant, String image) {
         checkout scm
         def manifests = load "ci-scripts/yocto.groovy"
 
-        manifests.buildManifest(variant, image, env.SMOKE_TEST == "true")
+        manifests.buildManifest(variant, image)
     }
 }
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
     config.vm.provider "docker" do |d, configOverride|
         d.build_dir = "."
         d.has_ssh = true
-        d.build_args = ['--build-arg', 'userid=' + `id -u`.strip]
+        d.build_args = ['--build-arg', 'userid=' + `id -u`.strip, '--build-arg', 'groupid=' + `id -g`.strip]
         d.create_args = ['--cap-add=NET_ADMIN', '--device=/dev/net/tun']
 
         # Overrides for 'config' unique for docker

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -159,7 +159,6 @@ void archiveArtifacts(String yoctoDir, String suffix) {
 }
 
 void buildWithLayer(String variantName, String imageName, String layer, String layerPath) {
-    // Store the directory we are executed in as our workspace.
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
 
@@ -197,7 +196,6 @@ void replaceLayer(String yoctoDir, String layerName, String newPath) {
 }
 
 void buildManifest(String variantName, String imageName) {
-    // Store the directory we are executed in as our workspace.
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
 

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -199,7 +199,7 @@ void replaceLayer(String yoctoDir, String layerName, String newPath) {
     vagrant("mv /vagrant/${layerName} ${yoctoDir}/sources/")
 }
 
-void buildManifest(String variantName, String imageName, boolean smokeTests=false) {
+void buildManifest(String variantName, String imageName) {
     // Store the directory we are executed in as our workspace.
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
@@ -214,6 +214,7 @@ void buildManifest(String variantName, String imageName, boolean smokeTests=fals
         // Setup yocto
         String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variantName}"
         boolean archive = env.ARCHIVE_CACHE == "true"
+        boolean smokeTests = env.SMOKE_TEST == "true"
         setupBitbake(yoctoDir, templateConf, archive, smokeTests)
         setupCache(yoctoDir, env.YOCTO_CACHE_URL)
 

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -39,9 +39,10 @@ void shutdownVagrant() {
     }
 }
 
-void repoInit(String manifest) {
+void repoInit(String manifest, String yoctoDir) {
     stage("Repo init") {
-        vagrant("/vagrant/ci-scripts/do_repo_init ${manifest}")
+        syncDir = "/vagrant"
+        vagrant("/vagrant/ci-scripts/do_repo_init ${manifest} ${syncDir} ${yoctoDir}")
     }
 }
 
@@ -177,7 +178,7 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
     try {
         // Initialize vagrant and repo manifest
         startVagrant()
-        repoInit(manifest)
+        repoInit(manifest, yoctoDir)
 
         if (layerToReplace != "" && newLayerPath != "") {
             replaceLayer(yoctoDir, layerToReplace, newLayerPath)

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -7,11 +7,9 @@ int vagrant(String command, boolean saveStatus=false) {
     sh returnStatus: saveStatus, script: "vagrant ssh -c \"${command}\""
 }
 
-// Helper to do checkout and update submodules
-void checkoutWithSubmodules() {
-    // Checkout the git repository and refspec pointed to by jenkins
-    stage("Checkout") {
-        checkout scm
+// Helper to do checkout and update of submodules.
+void gitSubmoduleUpdate() {
+    stage("Update submodules") {
         sh "git submodule update --init"
     }
 }
@@ -165,9 +163,8 @@ void buildWithLayer(String variantName, String imageName, String layer, String l
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
 
-    // We can't do "checkout scm" here since pelux-manifests is not the
-    // canonical repo here.
-    sh "git submodule update --init"
+    gitSubmoduleUpdate()
+
     try {
         // Initialize vagrant and repo manifest
         startVagrant()
@@ -204,8 +201,8 @@ void buildManifest(String variantName, String imageName) {
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
 
-    // Initialize code
-    checkoutWithSubmodules()
+    gitSubmoduleUpdate()
+
     try {
         // Initialize vagrant and repo manifest
         startVagrant()

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -159,34 +159,7 @@ void archiveArtifacts(String yoctoDir, String suffix) {
 }
 
 void buildWithLayer(String variantName, String imageName, String layer, String layerPath) {
-    String yoctoDir = "/home/yoctouser/pelux_yocto"
-    String manifest = "pelux.xml"
-
-    gitSubmoduleUpdate()
-
-    try {
-        // Initialize vagrant and repo manifest
-        startVagrant()
-        repoInit(manifest)
-
-        replaceLayer(yoctoDir, layer, layerPath)
-
-        // Setup yocto
-        String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variantName}"
-        boolean archive = env.ARCHIVE_CACHE == "true"
-        setupBitbake(yoctoDir, templateConf, archive)
-        setupCache(yoctoDir, env.YOCTO_CACHE_URL)
-
-        // Build the images
-        try {
-            boolean buildUpdate = variantName.startsWith("rpi")
-            buildImageAndSDK(yoctoDir, imageName, variantName, buildUpdate)
-        } finally { // Archive cache even if there were errors.
-            archiveCache(yoctoDir, archive, env.YOCTO_CACHE_ARCHIVE_PATH)
-        }
-    } finally {
-        shutdownVagrant()
-    }
+    buildManifest(variantName, imageName, layerToReplace=layer, newLayerPath=layerPath)
 }
 
 void replaceLayer(String yoctoDir, String layerName, String newPath) {
@@ -195,7 +168,7 @@ void replaceLayer(String yoctoDir, String layerName, String newPath) {
     vagrant("mv /vagrant/${layerName} ${yoctoDir}/sources/")
 }
 
-void buildManifest(String variantName, String imageName) {
+void buildManifest(String variantName, String imageName, String layerToReplace="", String newLayerPath="") {
     String yoctoDir = "/home/yoctouser/pelux_yocto"
     String manifest = "pelux.xml"
 
@@ -205,6 +178,10 @@ void buildManifest(String variantName, String imageName) {
         // Initialize vagrant and repo manifest
         startVagrant()
         repoInit(manifest)
+
+        if (layerToReplace != "" && newLayerPath != "") {
+            replaceLayer(yoctoDir, layerToReplace, newLayerPath)
+        }
 
         // Setup yocto
         String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variantName}"

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -169,8 +169,15 @@ void replaceLayer(String yoctoDir, String layerName, String newPath) {
     vagrant("mv /vagrant/${layerName} ${yoctoDir}/sources/")
 }
 
+void deleteYoctoBuildDir(String buildDir) {
+    stage("Deleting Yocto build directory") {
+        sh "rm -rf ${buildDir}"
+    }
+}
+
 void buildManifest(String variantName, String imageName, String layerToReplace="", String newLayerPath="") {
-    String yoctoDir = "/home/yoctouser/pelux_yocto"
+    String yoctoDirInWorkspace = "pelux_yocto"
+    String yoctoDir = "/vagrant/${yoctoDirInWorkspace}" // On bind mount to avoid overlay2 fs.
     String manifest = "pelux.xml"
 
     gitSubmoduleUpdate()
@@ -208,6 +215,7 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
         }
     } finally {
         shutdownVagrant()
+        deleteYoctoBuildDir("${yoctoDirInWorkspace}")
     }
 }
 


### PR DESCRIPTION
Have run a couple of full builds (intel, intel-qtauto, rpi and rpi-qtauto) on stockholm, reykjavik, kyiv and helsinki with this and all intermittent build errors are gone. Did not manage to pass a single full build on any of these nodes before.