### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -31,7 +31,7 @@
 
   <project remote="github"
            upstream="rocko"
-           revision="e217d8000cecb82574b83bdf81350cdf58ee3808"
+           revision="3b200c39cbb28ab757f905553a36611ad64d9983"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux" />
 


### PR DESCRIPTION
CI/CD builds break very often without gammaray fix.

meta-pelux shortlog:
    qtbase: fix intermittent rpi-qtauto gammaray build failures

Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>