### PR TITLE
Add bitbake tests and a few rpm tests. Also the -dev image has to be specified from now and on. 

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -94,8 +94,7 @@ void buildImageAndSDK(String yoctoDir, String imageName, String variantName, boo
     }
 
     stage("Bitbake ${imageName} for ${variantName}") {
-        vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}")
-        vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}-dev")
+        vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}")       
 
         if (update) {
             stage("Bitbake Update ${imageName} for ${variantName}") {
@@ -110,7 +109,6 @@ void buildImageAndSDK(String yoctoDir, String imageName, String variantName, boo
     if (nightly || weekly) {
         stage("Build SDK ${imageName}") {
             vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${imageName}")
-            vagrant("/vagrant/cookbook/yocto/build-sdk.sh ${yoctoDir} ${imageName}-dev")
         }
     }
 }
@@ -121,7 +119,7 @@ void runSmokeTests(String yoctoDir, String imageName) {
 
     try {
         stage("Perform smoke testing") {
-            vagrant("/vagrant/cookbook/yocto/runqemu-smoke-test.sh ${yoctoDir} ${imageName}-dev")
+            vagrant("/vagrant/cookbook/yocto/runqemu-smoke-test.sh ${yoctoDir} ${imageName}")
         }
     } catch(e) {
         echo "There were failing tests"
@@ -139,15 +137,7 @@ void runSmokeTests(String yoctoDir, String imageName) {
 void runBitbakeTests(String yoctoDir) {
     stage("Perform Bitbake Testing"){
         vagrant("/vagrant/cookbook/yocto/run-bitbake-tests.sh ${yoctoDir} ")
-    }
-    
-    //stage("Publish bitbake test results") {
-    //    reportsDir="/vagrant/${archiveDir}/test_reports/bitbake_tests/"
-    //    vagrant("mkdir -p ${reportsDir}")
-    //    vagrant("cp -a ${yoctoDir}/build/TestResults* ${reportsDir}")
-    //    junit "${archiveDir}/test_reports/bitbake_Tests/TestResults*/*.xml"
-    //}
-    
+    } 
 }
 
 

--- a/test-scripts/local.conf.appendix
+++ b/test-scripts/local.conf.appendix
@@ -19,7 +19,6 @@ TEST_SUITES = " \
     systemd.SystemdBasicTests.test_systemd_failed \
     systemd.SystemdBasicTests.test_systemd_list \
     systemd.SystemdJournalTests.test_systemd_journal \
-    rpm.RpmBasicTest \
     rpm.RpmInstallRemoveTest.test_rpm_install \
     rpm.RpmInstallRemoveTest.test_rpm_query_nonroot \
     rpm.RpmInstallRemoveTest.test_rpm_remove \

--- a/test-scripts/local.conf.appendix
+++ b/test-scripts/local.conf.appendix
@@ -19,5 +19,9 @@ TEST_SUITES = " \
     systemd.SystemdBasicTests.test_systemd_failed \
     systemd.SystemdBasicTests.test_systemd_list \
     systemd.SystemdJournalTests.test_systemd_journal \
+    rpm.RpmBasicTest \
+    rpm.RpmInstallRemoveTest.test_rpm_install \
+    rpm.RpmInstallRemoveTest.test_rpm_query_nonroot \
+    rpm.RpmInstallRemoveTest.test_rpm_remove \
     auto \
 "


### PR DESCRIPTION
Bitbake tests help avoid regressions when working on bitbake. 

RPM tests that currently pass are also added to the test suite. 