### PR TITLE
ci-scripts/do_repo_init: set repo init depth to 1

### DIFF
--- a/ci-scripts/do_repo_init
+++ b/ci-scripts/do_repo_init
@@ -67,5 +67,5 @@ cd -
 # Clone recipes
 mkdir "$YOCTO_DIR"
 cd "$YOCTO_DIR"
-time repo init -u ${COPY_DIR} -m ${MANIFEST} -b master
+time repo init --depth=20 -u ${COPY_DIR} -m ${MANIFEST} -b master
 time repo sync


### PR DESCRIPTION
Set depth for `repo init` to '1' to save time and bandwidth on checking
out repositories.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>