### PR TITLE
yocto.groovy: do not pass -l flag to rsync

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -138,8 +138,8 @@ void runSmokeTests(String yoctoDir, String imageName) {
 void archiveCache(String yoctoDir, boolean archive, String archivePath) {
     if (archive && archivePath?.trim()) {
         stage("Archive cache") {
-            vagrant("rsync -trpgOl ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
-            vagrant("rsync -trpgOl ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
+            vagrant("rsync -trpgO ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
+            vagrant("rsync -trpgO ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
         }
     }
 }


### PR DESCRIPTION
Partial revert of 47f53f51f30caba0b49cb8d3d4cb8852e9594265 .

Keep -O flag from the above commit since the rsync man pages says it is
good to do so if NFS is used on the receiving side, which is the case in
our current setup.

BitBake creates symlinks to files in the cache when the cache is located
on the local filesystem. If -l is passed to rsync these symlinks are copied
out to the cache after a build which results in symlinks that refer to
themselves.

Ideally we would want to preserve relative symlinks within the build dir,
but it does not look like BitBake creates any at the moment.

Signed-off-by: Martin Ejdestig <mejdestig@luxoft.com>