### PR TITLE
pelux.xml: bump meta-arp

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -90,7 +90,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="3fdf5b15de028c2f7226bcf19cb7a08aa31e0f4d"
+           revision="fdc1042deb6278890b15418bae7a70772fe6b2dd"
            name="Pelagicore/meta-arp"
            path="sources/meta-arp"/>
 


### PR DESCRIPTION
- conf/layer.conf: set LAYERSERIES_COMPAT
- Load the arp-camera module automatically when the arp module is loaded
- Remove the Altera TSE driver from the kernel build

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>