### PR TITLE
yocto.groovy: remove use of named arguments when calling buildManifest()

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -166,7 +166,7 @@ void archiveArtifacts(String yoctoDir, String suffix) {
 }
 
 void buildWithLayer(String variantName, String imageName, String layer, String layerPath) {
-    buildManifest(variantName, imageName, layerToReplace=layer, newLayerPath=layerPath)
+    buildManifest(variantName, imageName, layer, layerPath)
 }
 
 void replaceLayer(String yoctoDir, String layerName, String newPath) {


### PR DESCRIPTION
Apparently named arguments do not work when Jenkins runs the Groovy code in a JenkinsFile. The values that gets passed are null. Named arguments work as expected when used in the script console ("Manage Jenkins" -> "Script Console") though. No idea why.

Fixes building of meta-pelux that calls buildWithLayer() in its JenkinsFile. Example of error output without this fix:

```
[intel-qtauto] [pelux-manifests] Running shell script
[intel-qtauto] + vagrant ssh -c rm -rf /vagrant/pelux_yocto/sources/null
[Pipeline] [intel-qtauto] sh
[intel-qtauto] [pelux-manifests] Running shell script
[intel-qtauto] + cp -R null null
[intel-qtauto] cp: cannot stat 'null': No such file or directory
```