### PR TITLE
test-scripts/local.conf: remove auto tests temporarily

### DIFF
--- a/test-scripts/local.conf.appendix
+++ b/test-scripts/local.conf.appendix
@@ -22,5 +22,4 @@ TEST_SUITES = " \
     rpm.RpmInstallRemoveTest.test_rpm_install \
     rpm.RpmInstallRemoveTest.test_rpm_query_nonroot \
     rpm.RpmInstallRemoveTest.test_rpm_remove \
-    auto \
 "

--- a/test-scripts/local.conf.appendix
+++ b/test-scripts/local.conf.appendix
@@ -19,6 +19,7 @@ TEST_SUITES = " \
     systemd.SystemdBasicTests.test_systemd_failed \
     systemd.SystemdBasicTests.test_systemd_list \
     systemd.SystemdJournalTests.test_systemd_journal \
+    rpm.RpmBasicTest \
     rpm.RpmInstallRemoveTest.test_rpm_install \
     rpm.RpmInstallRemoveTest.test_rpm_query_nonroot \
     rpm.RpmInstallRemoveTest.test_rpm_remove \


### PR DESCRIPTION
Test scripts have been failing because of a package (galculator) being unable
to be tar-ed. Its format is bz2 but neither bzip2, or lbzip2 was installed
on the target. This is not a fix, this is a temporarily workaround.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>