### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="db4cecf9ce504efd7d28e17ef4896fef45b997fe"
+           revision="659686ef139cd7f7c578bc37458296a5338d9d76"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux" />
 


### PR DESCRIPTION
To revision with fix for linking error in QtScript for rpi. Will hopefully mean that tonight's nightly will be all green.

meta-pelux shortlog:
- qtscript: disable lto on ARM
- local.conf.sample: set PREFERRED_PROVIDER for iasl-native