### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="161eaa28ed16f93d57f3d1c4be84f894e99ab72e"
+           revision="36d5cee56bd389ecbe66dbfad9e5d57c13b56b95"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Bumped to include fix for missing OEToolchainConfig.cmake in sdk

List of included commits:
- bitbake: fetcher: Fixed remote removal not throwing exception
- initramfs-framework/udev: call settle before kill
- libcroco: CVE-2017-7961
- gnupg: CVE-2018-9234
- qemux86-directdisk: remove mem= parameter
- cmake: put cmake.m4 and toolchain file in PN
- mkefidisk: fix installation of kernel image
- libsdl2: Fix left rotated display for RaspPi/VC4/GLES2
- security_flags: disable static PIE in glibc
- bitbake: main: Fix environment handling for UI module imports

Signed-off-by: Tariq Ansari <tansari@luxoft.com>