### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="36d5cee56bd389ecbe66dbfad9e5d57c13b56b95"
+           revision="d240b885f26e9b05c8db0364ab2ace9796709aad"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Changes included:
- externalsrc.bbclass: Set BB_DONT_CACHE for non-target recipes
- rootfs: always update the opkg index
- runqemu: fix handling of SIGTERM and the problem of line wrapping
- runqemu: exit gracefully with an error message if qemu system is not evaluated
- runqemu: add SIGTERM handler to make sure things are cleaned up
- libtiff: fix CVE-2017-17095
- x264: Disable asm on musl/x86
- libsndfile1: CVE-2018-13139
- nasm: fix CVE-2018-10016
- recipes: Update git.gnome.org addresses after upstream changes
- git: CVE-2018-11233
- python3: CVE-2018-1061
- libxml2: CVE-2018-14404
- checklayer: avoid recursive loop in add_layer_dependencies

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>