### PR TITLE
pelux.xml: bump meta-virtualization

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -51,7 +51,7 @@
 
   <project remote="yocto"
            upstream="sumo"
-           revision="dd32e94c88550d7629aa696acb565c1597954603"
+           revision="ed2038c935777d1336c17989d454f4e9c95fea7f"
            name="meta-virtualization"
            path="sources/meta-virtualization"/>
 


### PR DESCRIPTION
Changes included:
- lxc: make error report compatible with ptest
- lxc: use compiled tests instead of copying source building on target
- lxc: fixup 'download' template use
- docker: CVE-2018-10892

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>