### PR TITLE
pelux.xml: bump meta-boot2qt and meta-qt5

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -65,13 +65,13 @@
   <!-- Qt + Qt Automotive support stuff -->
   <project remote="code.qt"
            upstream="5.11"
-           revision="8e485a2bfa4632bfefea861c2a06d9a6e8fc5c33"
+           revision="e863df2be9e966811a80f0e3717af911478fd748"
            name="yocto/meta-qt5"
            path="sources/meta-qt5"/>
 
   <project remote="code.qt"
            upstream="sumo"
-           revision="7ca9ecbd2868c3462b7ac1c300e9c236c7f8365b"
+           revision="b6dd26d488c1e9dd3339743e436dbdfa6fdc96e9"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 


### PR DESCRIPTION
meta-boot2qt:
- meta-qt5: update layer
- poky, openembedded: update meta layers
- renesas: add workaround for qtwebengine
- meta-qt5: update layer
- jetson-tx1: use basic render roop
- renesas: revert to working libgbm
- qtbase: update .bbappend
- rng-tools: update rng-tools .bbappend
- Add configuration to build non-(L)GPLv3 image

meta-qt5:
- nativesdk-qtbase: fix packaging QA issue
- Merge remote-tracking branch 'qtyocto/upstream/master' into 5.11
- layer.conf: Add thud to LAYERSERIES_COMPAT
- qt5-creator: Check before editing translation Makefile
- qt5-creator: Pick native tools from native sysroot e.g. lrelease etc.
- qt5-creator: fix build with QMAKE_AR
- qt5-creator: upgrade to 4.7.1+
- qt: package all files in ${PN}-examples
- qt: use single -dev and -staticdev package
- qt5-creator: refresh .patch files and push them to meta-qt5 fork
- qt5-creator: Fix build due to missing lrelease
- qtchooser: Update to latest git
- qtwebengine: Add patches to fix breakpad in new webengine release on musl
- qtbase: Do not use cross_compile check
- qtbase: Fix errors due to -isystem
- qtbase: Fix build error for armv8BE multilib.
- qt5: update to latest revision in 5.11 branch
- qt5: update to Qt 5.11.2
- libqofono: include /qt5/mkspecs in ${PN}-dev
- qtwebkit-examples: Fix build with QT 5.11
- qtwebkit: Use relative paths for pri files when cross compile
- qmake5_paths: change the default QT_DIR_NAME to be empty
- nativesdk-qtbase: use default PACKAGES
- qt5-creator: strip few more useless rpaths
- qt: remove unnecessary FILES.*-dbg variables for packaging .debug files
- qt3d-runtime: Fix compile errors as seen with mips/musl
- qt3d-runtime: upgrade to latest revision in 2.0 branch
- qtwebkit: Make qtwebkit support arm32 BE.
- qtscript: add patches to meta-qt5 fork
- qtscript: Fix build on musl
- qtwebkit: add patches to meta-qt5 fork
- qtwebkit: Fix conflicts with -I and -isystem
- qtwebkit: Fix build with musl
- qt5-creator: Strip out redundant RPATH
- qt5-creator: Fix building botan for all non-x86 arches
- qtwebengine: use nasm-native instead of yasm-native
- qtbase: fix install locations used in static builds
- qtwebengine: enable debug info for webengine

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>