### PR TITLE
pelux.xml: bump meta-bistro

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -26,7 +26,7 @@
   <!-- Pelagicore/Luxoft stuff -->
   <project remote="github"
            upstream="master"
-           revision="62a422a4ae42ef05b4a0c902664fe3a69184ab82"
+           revision="1b081729e96379c450d3dac2cab02c468595a0e1"
            name="Pelagicore/meta-bistro"
            path="sources/meta-bistro" />
 


### PR DESCRIPTION
To get simple-node-state-machine with crash fix for NSM.

meta-bistro:
- layer.conf: add thud to LAYERSERIES_COMPAT
- node-state-manager: add integration of NSM
- oeqa: add tests for node-state-manager
- oeqa: add tests for dlt-daemon
- oeqa: add tests for softwarecontainer