### PR TITLE
pelux.xml: bump meta-boot2qt

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -71,7 +71,7 @@
 
   <project remote="code.qt"
            upstream="sumo"
-           revision="b6dd26d488c1e9dd3339743e436dbdfa6fdc96e9"
+           revision="283d5bc109aa34a9fa51b870f3d9e21efcb215f2"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 

--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="sumo"
-           revision="ad03993c92b3b9dd751b5d7e2543b2b7bd82a630"
+           revision="6b24c4679fe28ef3eac697cad1343abb4aa1e1be"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
Changes included:
- sdk: fix linker flags
- intel: rework initramfs support
- Add optional init parameter to use non-default manifest directory
- sdk: remove unneeded compiler flags
- cmake: fix cmake configurations for QtCreator
- QBSP: add Qt version to the QBSP file name
- toradex: fix problem with basehash in tezi
- imx7s-warp: bring back kernel with display support
- qtgamepad: add QtGamePad to the image
- meta-qt5: update meta layer
- Update to GammaRay 2.10 for QtAS 5.12
- QBSP: add check for supported host system
- qtwebengine: remove LTCG override

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>