### PR TITLE
Add RPI image to the archive

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -30,6 +30,7 @@ SDK_DIR="${BUILD_DIR}/tmp/deploy/sdk"
 
 INTEL_ARCH="intel-corei7-64"
 ARP_ARCH="arp"
+RPI_ARCH="rasberrypi3"
 
 IMAGE_BASENAME="core-image-pelux"
 SDK_BASENAME="pelux-glibc"
@@ -42,8 +43,14 @@ fi
 
 # If there is an ARP directory
 if [ -d ${IMAGE_DIR}/${ARP_ARCH} ]; then
-    echo "Archiving Intel image to $ARCHIVE_DIR"
-    cp ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+    echo "Archiving ARP image to $ARCHIVE_DIR"
+    cp ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+fi
+
+# If there is an RPI directory
+if [ -d ${IMAGE_DIR}/${RPI_ARCH} ]; then
+    echo "Archiving RPI image to $ARCHIVE_DIR"
+    cp ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*.rpi-sdimg $ARCHIVE_DIR
 fi
 
 # Copy the SDK


### PR DESCRIPTION
This archive directory, might as well be used for further sharing of the artifacts, therefore having the rpi image here as well.

Besides adding rpi image, also fixed a few minor errors when archiving the ARP image.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>