### PR TITLE
pelux.xml: bump meta-boot2qt

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -71,7 +71,7 @@
 
   <project remote="code.qt"
            upstream="sumo"
-           revision="283d5bc109aa34a9fa51b870f3d9e21efcb215f2"
+           revision="0f486bc912ac5f2f938f981e7aa0f8a0c6366cd6"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 


### PR DESCRIPTION
Changes included:
- qbsp: use correct version number for automotive qbsp
- meta-qt5: update layer
- meta-qt5: update layer
- meta-qt5: update layer
- qtbase: disable ltcg on windows host
- qtdeviceutilities: update latest revision
- toradex: remove incorrect kernel config line

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>