### PR TITLE
pelux.xml: bump meta-boot2qt

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -71,7 +71,7 @@
 
   <project remote="code.qt"
            upstream="sumo"
-           revision="c22f4986715cc867391f77a7985935e7d4f5b5eb"
+           revision="8d854724ae70112e0961303ae8119510dedf799e"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 


### PR DESCRIPTION
Changes included:
- qtbase: disable lto for static libs
- emulator: remove invalid vga mode from boot parameters
- boot2qt-demos: update revision

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>