### PR TITLE
Do not build -dev images automatically

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -99,7 +99,6 @@ void buildImageAndSDK(String yoctoDir, String imageName, String variantName, boo
         if (update) {
             stage("Bitbake Update ${imageName} for ${variantName}") {
                 vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}-update")
-                vagrant("/vagrant/cookbook/yocto/build-images.sh ${yoctoDir} ${imageName}-dev-update")
             }
         }
     }


### PR DESCRIPTION
When you build the -dev image automatically, it means that
when you try to actually build a dev image, it will go on the
update image as well and do the "-dev-dev-update". This is
inconsistent with the other builds that we do and whenever we try to
build rpi -dev images, it always fails because of not finding the
specified image.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>