### PR TITLE
pelux.xml: bump meta-boot2qt and meta-qt5

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -65,13 +65,13 @@
   <!-- Qt + Qt Automotive support stuff -->
   <project remote="code.qt"
            upstream="5.11"
-           revision="e863df2be9e966811a80f0e3717af911478fd748"
+           revision="ff6127ddd318d422f595295d1c189a86b3032873"
            name="yocto/meta-qt5"
            path="sources/meta-qt5"/>
 
   <project remote="code.qt"
            upstream="sumo"
-           revision="8d854724ae70112e0961303ae8119510dedf799e"
+           revision="1aafad3d9148ae2f09ae73d07c99ca7bc14c4ae2"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 


### PR DESCRIPTION
This bump brings Qt 5.11.3.

meta-boot2qt:
- qtapplicationmanager: update revision
- Tell people to run b2qt-init-build-env in a new directory

meta-qt5:
- python-pyqt5: Update to 5.11.3 and add python3 recipe
- qtbase-native: disable postgresql support
- qtbase: refresh patches and update tags on meta-qt5
- qtbase: don't leak absolut path to recipe specific sysroot
- qt5: Disable ltcg for host_build
- qtbase: don't use thumb for armv[45]
- qt5: update submodules
- qtdeclarative: fix inconsistent QML_COMPILE_HASH value

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>