### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="d240b885f26e9b05c8db0364ab2ace9796709aad"
+           revision="eebbc00b252a84d2502c3f5c7acd5a622dbd6e31"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
- oeqa/selftest/runtime_test: Ensure we build/use gnupg-native
- curl: Include the complete license information
- curl: CVE-2018-14618
- apt: update SRC_URI
- nasm: fix CVE-2018-1000667
- m4: Workaround gnulib's fseeko.c implementation
- python: backport patch to fix CVE-2018-14647
- python: backport patch to fix CVE-2018-1000802
- python: don't use runtime checks to identify float endianism
- python: clean up ptest
- python: update to version 2.7.15
- linux-yocto/4.14: update to v4.14.76
- linux-yocto-rt: fixup 4.14 merge issues
- linux-yocto/4.14: fix beaglebone configuration warnings
- linux-yocto: enable pci and CRYPTO_DEV_VIRTIO
- linux-yocto/4.14: update to v4.14.71
- linux-yocto/4.14: fix kernel configuration audit warnings
- linux-yocto: tweak RTC configuration
- linux-yocto: configuration warning fixes
- linux-yocto-rt: Add paravirt_kvm support for qemux86-64
- linux-yocto/4.14/4.18: address kernel configuration warnings
- kernel-yocto/cfg: configuration warning fixes
- base-files: change permissions on /sys and /proc
- os-release: move to nonarch_libdir
- tzdata: update to 2018f
- tzcode: update to 2018f
- tzdata: update to 2018e
- tzcode-native: updatet to 2018e
- curl: extend CVE_PRODUCT
- cve-check: Allow multiple entries in CVE_PRODUCT
- yocto-uninative: Upgrade to verson 2.3 which includes glibc 2.28
- kernel: specify dependencies for compilation for config tasks
- valgrind: fix compile ptest failure on mips32
- valgrind: fix ptest compilation for PowerPC64
- perl: skip tests that are not useful

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>