### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="eebbc00b252a84d2502c3f5c7acd5a622dbd6e31"
+           revision="64a257fa22126c4a40ff7e03424a404e360ebe1e"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
- gnupg: patch gnupg-native to allow path relocationsumo
- bitbake: bitbake: toaster: allow OE_ROOT to be provided through environment
- dhcp: allow for excluding the external bind
- curl: actually apply latest CVE patches
- unzip: actually apply CVE-2018-18384
- oeqa/selftest/recipetool: Fix problems from changing upstream source
- base.bbclass: avoid 'find -ignore_readdir_race -delete'
- archiver: Drop unwanted directories
- meta: Use double colon for chown OWNER:GROUP
- crosssdk: Remove usage of host flags for cross-compilation
- pixman: Trim license info extracted from pixman-matrix.c
- apr-util: Trim license info extracted from apu_version.h
- apr: Trim license info extracted from apr_lib.h
- common-licenses: Correct the FreeType license text
- curl: fix for CVE-2018-16839/CVE-2018-16840/CVE-2018-16842
- unzip: fix for CVE-2018-18384
- wic: isoimage-isohybrid: fix UEFI spec breakage
- selftest/wic: Improve error message for test_fixed_size
- oeqa/selftest/wic: Ensure initramfs exists for test_iso_image
- oeqa/selftest/wic: Use a subdir of builddir, not /var/
- kernel-dev: Updated phrasing for what a "defconfig" file is.

Signed-off-by: Tariq Ansari <tansari@luxoft.com>