### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -19,7 +19,7 @@
 
   <project remote="yocto"
            upstream="rocko"
-           revision="0d6e6eb5101c1f24dabd4232d8a08369512c69e3"
+           revision="68a612b7d31d270348ef5439d7f779c309bdb6ec"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
- python-3.5: Fix manifest to handle reprlib correctlyrocko
- bitbake: main: Fix environment handling for UI module imports
- Documentation: Updated month and year date for 2.4.4 release.
- build-appliance-image: Update to rocko head revision
- poky.conf: Bump version for 2.4.4 rocko release
- linux-yoct-rt/4.4: update to 4.4.162
- linux-yocto-tiny/4.4: update to 4.4.162
- linux-yocto/4.4: update to 4.4.162
- linux-yocto/4.12: update to v4.12.28
- linux-yocto/4.12: update to v4.12.26
- linux-yocto/4.12: bump to v4.12.25
- linux-yocto/4.12: gcc8 + platform support
- yocto-uninative: Upgrade to verson 2.3 which includes glibc 2.28
- os-release: move to nonarch_libdir
- os-release: fix to install in the expected location
- tzdata: update to 2018f
- tzcode: update to 2018f
- tzdata: update to 2018e
- tzcode-native: updatet to 2018e
- tzcode-native: update to 2018d
- tzdata: update to 2018d
- tzcode: remove unused patch files
- valgrind: fix compile ptest failure on mips32
- valgrind: fix ptest compilation for PowerPC64
- valgrind: fix the shared object issue while prelink ptest
- valgrind: Mask CPUID support in HWCAP on aarch64
- toolchain-scripts: preserve host path in environment setup script
- lsb/lsbtests: Update package lists to use latest version of binary
- perl: skip tests that are not useful

Signed-off-by: Tariq Ansari <tansari@luxoft.com>