### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="36d5cee56bd389ecbe66dbfad9e5d57c13b56b95"
+           revision="64a257fa22126c4a40ff7e03424a404e360ebe1e"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
- gnupg: patch gnupg-native to allow path relocationsumo
- bitbake: bitbake: toaster: allow OE_ROOT to be provided through environment
- dhcp: allow for excluding the external bind
- curl: actually apply latest CVE patches
- unzip: actually apply CVE-2018-18384
- oeqa/selftest/recipetool: Fix problems from changing upstream source
- base.bbclass: avoid 'find -ignore_readdir_race -delete'
- archiver: Drop unwanted directories
- meta: Use double colon for chown OWNER:GROUP
- crosssdk: Remove usage of host flags for cross-compilation
- pixman: Trim license info extracted from pixman-matrix.c
- apr-util: Trim license info extracted from apu_version.h
- apr: Trim license info extracted from apr_lib.h
- common-licenses: Correct the FreeType license text
- curl: fix for CVE-2018-16839/CVE-2018-16840/CVE-2018-16842
- unzip: fix for CVE-2018-18384
- wic: isoimage-isohybrid: fix UEFI spec breakage
- selftest/wic: Improve error message for test_fixed_size
- oeqa/selftest/wic: Ensure initramfs exists for test_iso_image
- oeqa/selftest/wic: Use a subdir of builddir, not /var/
- kernel-dev: Updated phrasing for what a "defconfig" file is.
- oeqa/selftest/runtime_test: Ensure we build/use gnupg-native
- curl: Include the complete license information
- curl: CVE-2018-14618
- apt: update SRC_URI
- nasm: fix CVE-2018-1000667
- m4: Workaround gnulib's fseeko.c implementation
- python: backport patch to fix CVE-2018-14647
- python: backport patch to fix CVE-2018-1000802
- python: don't use runtime checks to identify float endianism
- python: clean up ptest
- python: update to version 2.7.15
- linux-yocto/4.14: update to v4.14.76
- linux-yocto-rt: fixup 4.14 merge issues
- linux-yocto/4.14: fix beaglebone configuration warnings
- linux-yocto: enable pci and CRYPTO_DEV_VIRTIO
- linux-yocto/4.14: update to v4.14.71
- linux-yocto/4.14: fix kernel configuration audit warnings
- linux-yocto: tweak RTC configuration
- linux-yocto: configuration warning fixes
- linux-yocto-rt: Add paravirt_kvm support for qemux86-64
- linux-yocto/4.14/4.18: address kernel configuration warnings
- kernel-yocto/cfg: configuration warning fixes
- base-files: change permissions on /sys and /proc
- os-release: move to nonarch_libdir
- tzdata: update to 2018f
- tzcode: update to 2018f
- tzdata: update to 2018e
- tzcode-native: updatet to 2018e
- curl: extend CVE_PRODUCT
- cve-check: Allow multiple entries in CVE_PRODUCT
- yocto-uninative: Upgrade to verson 2.3 which includes glibc 2.28
- kernel: specify dependencies for compilation for config tasks
- valgrind: fix compile ptest failure on mips32
- valgrind: fix ptest compilation for PowerPC64
- perl: skip tests that are not useful
- externalsrc.bbclass: Set BB_DONT_CACHE for non-target recipes
- rootfs: always update the opkg index
- runqemu: fix handling of SIGTERM and the problem of line wrapping
- runqemu: exit gracefully with an error message if qemu system is not evaluated
- runqemu: add SIGTERM handler to make sure things are cleaned up
- libtiff: fix CVE-2017-17095
- x264: Disable asm on musl/x86
- libsndfile1: CVE-2018-13139
- nasm: fix CVE-2018-10016
- recipes: Update git.gnome.org addresses after upstream changes
- git: CVE-2018-11233
- python3: CVE-2018-1061
- libxml2: CVE-2018-14404
- checklayer: avoid recursive loop in add_layer_dependencies

Signed-off-by: Tariq Ansari <tansari@luxoft.com>