### PR TITLE
Revert "yocto.groovy: Run compatibility tests on every build"

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -218,12 +218,12 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
         try {
             boolean buildUpdate = variantName.startsWith("rpi")
             buildImageAndSDK(yoctoDir, imageName, variantName, buildUpdate)
-            runYoctoCheckLayer(yoctoDir)
             if (smokeTests) {
                 boolean weekly = env.WEEKLY_BUILD == "true"
                 runSmokeTests(yoctoDir, imageName)
                 if(weekly) {
                     runBitbakeTests(yoctoDir)
+                    runYoctoCheckLayer(yoctoDir)
                 }
             }
 


### PR DESCRIPTION
This reverts commit 5c7aad156de24ca91512f1c50179fd78ec153881.

Since virtually all the layers contain compatibility issues which we
can not fix, every build fails due to this check failing.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>