### PR TITLE
copy_to_archive: move artifacts instead of copying

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -35,26 +35,26 @@ RPI_ARCH="rasberrypi3"
 IMAGE_BASENAME="core-image-pelux"
 SDK_BASENAME="pelux-glibc"
 
-# If there is an intel directory
+# If there is an Intel directory
 if [ -d ${IMAGE_DIR}/${INTEL_ARCH} ]; then
     echo "Archiving Intel image to $ARCHIVE_DIR"
-    cp ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
 fi
 
 # If there is an ARP directory
 if [ -d ${IMAGE_DIR}/${ARP_ARCH} ]; then
     echo "Archiving ARP image to $ARCHIVE_DIR"
-    cp ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
 fi
 
 # If there is an RPI directory
 if [ -d ${IMAGE_DIR}/${RPI_ARCH} ]; then
     echo "Archiving RPI image to $ARCHIVE_DIR"
-    cp ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*.rpi-sdimg $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*.rpi-sdimg $ARCHIVE_DIR
 fi
 
 # Copy the SDK
 if [ -d ${SDK_DIR} ]; then
     echo "Archiving SDK to $ARCHIVE_DIR"
-    cp ${SDK_DIR}/${SDK_BASENAME}-*.sh $ARCHIVE_DIR
+    mv ${SDK_DIR}/${SDK_BASENAME}-*.sh $ARCHIVE_DIR
 fi


### PR DESCRIPTION
Move operation takes less time than copy. Moreover, build directory
gets eventually deleted together with the original artifact files.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>