### PR TITLE
Jenkinsfile: add a job specific variant list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ try {
     println "[\"${variantList.join('", "')}\"]"
 } catch(e) {
     println(e.getMessage())
-    echo "Using the default \"VARIANT_LIST\" for build"
+    echo "Using the default variant list for build"
     variantList = ['intel-qtauto:core-image-pelux-qtauto-neptune-dev',
                     'rpi-qtauto:core-image-pelux-qtauto-neptune-dev']
     println "[\"${variantList.join('", "')}\"]"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,21 @@ void buildOnYoctoNode(String variant, String image) {
 }
 
 def variantMap = [:]
-def variantList = env.VARIANT_LIST.split()
+def variantList = []
+
+// If VARIANT_LIST is defined in the Jenkins Environment
+// then use that, otherwise use the default
+try {
+    variantList = env.VARIANT_LIST.split()
+    echo "Using the specified variant list for build"
+    println "[\"${variantList.join('", "')}\"]"
+} catch(e) {
+    println(e.getMessage())
+    echo "Using the default \"VARIANT_LIST\" for build"
+    variantList = ['intel-qtauto:core-image-pelux-qtauto-neptune-dev',
+                    'rpi-qtauto:core-image-pelux-qtauto-neptune-dev']
+    println "[\"${variantList.join('", "')}\"]"
+}
 
 variantList.each {
     def list = it.split(":")


### PR DESCRIPTION
Since the global variant list from the Jenkins env overrides the
job specific list (due to an issue in Jenkins) we add this as a
workaround.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>