### PR TITLE
ISAFW: Run image security analysis on images

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -14,6 +14,7 @@ ARCHIVE_DIR="$2"
 
 IMAGE_DIR="${BUILD_DIR}/tmp/deploy/images"
 SDK_DIR="${BUILD_DIR}/tmp/deploy/sdk"
+LOG_DIR="${BUILD_DIR}/tmp/log"
 
 INTEL_ARCH="intel-corei7-64"
 ARP_ARCH="arp"
@@ -21,6 +22,12 @@ RPI_ARCH="rasberrypi3"
 
 IMAGE_BASENAME="core-image-pelux"
 SDK_BASENAME="pelux-glibc"
+
+# Copy the logs
+if [ -d ${LOG_DIR}/isafw-logs ]; then
+	echo "Archiving logs to $ARCHIVE_DIR"
+	mv ${LOG_DIR}/isafw-report_*/* $ARCHIVE_DIR
+fi
 
 # If there is an Intel directory
 if [ -d ${IMAGE_DIR}/${INTEL_ARCH} ]; then
@@ -45,3 +52,5 @@ if [ -d ${SDK_DIR} ]; then
     echo "Archiving SDK to $ARCHIVE_DIR"
     mv ${SDK_DIR}/${SDK_BASENAME}-*.sh $ARCHIVE_DIR
 fi
+
+

--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -46,7 +46,7 @@ void repoInit(String manifest, String yoctoDir) {
     }
 }
 
-void setupBitbake(String yoctoDir, String templateConf, boolean archive, boolean smokeTests=false) {
+void setupBitbake(String yoctoDir, String templateConf, boolean doArchiveCache, boolean smokeTests=false, boolean analyzeImage=false) {
     stage("Setup bitbake") {
         vagrant("/vagrant/cookbook/yocto/initialize-bitbake.sh ${yoctoDir} ${templateConf}")
 
@@ -60,10 +60,15 @@ void setupBitbake(String yoctoDir, String templateConf, boolean archive, boolean
                 vagrant("cat /vagrant/conf/test-scripts/local.conf.appendix >> ${yoctoDir}/build/conf/local.conf")
             }
         }
-        if (archive){
+        if (doArchiveCache){
             //Mirror git repositories
             vagrant("cat /vagrant/conf/local.conf_mirror.appendix >> ${yoctoDir}/build/conf/local.conf")
 
+        }
+        if (analyzeImage){
+            //Set up the configuration for running ISAFW
+            vagrant ("cat /vagrant/conf/isafw.local.conf >> ${yoctoDir}/build/conf/local.conf")
+            vagrant ("cat /vagrant/conf/isafw.bblayers.conf >> ${yoctoDir}/build/conf/bblayers.conf")
         }
     }
 }
@@ -150,8 +155,8 @@ void runYoctoCheckLayer(String yoctoDir) {
 }
 
 
-void archiveCache(String yoctoDir, boolean archive, String archivePath) {
-    if (archive && archivePath?.trim()) {
+void archiveCache(String yoctoDir, boolean doArchiveCache, String archivePath) {
+    if (doArchiveCache && archivePath?.trim()) {
         stage("Archive cache") {
             vagrant("rsync -trpgO ${yoctoDir}/build/downloads/ ${archivePath}/downloads/")
             vagrant("rsync -trpgO ${yoctoDir}/build/sstate-cache/ ${archivePath}/sstate-cache")
@@ -165,7 +170,6 @@ void archiveImagesAndSDK(String yoctoDir, String suffix) {
 
         sh "rm -rf ${artifactDir}"
         sh "mkdir ${artifactDir}"
-
         // Copy images and SDK to the synced directory
         vagrant("/vagrant/ci-scripts/copy_to_archive ${yoctoDir}/build /vagrant/${artifactDir}")
 
@@ -243,14 +247,16 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
 
         // Setup yocto
         String templateConf="${yoctoDir}/sources/meta-pelux/conf/variant/${variantName}"
+
         boolean doArchiveCache = getBoolEnvVar("ARCHIVE_CACHE", false)
         boolean smokeTests = getBoolEnvVar("SMOKE_TEST", false)
-        setupBitbake(yoctoDir, templateConf, doArchiveCache, smokeTests)
+        setupBitbake(yoctoDir, templateConf, doArchiveCache, smokeTests, analyzeImage)
         setupCache(yoctoDir, yoctoCacheURL)
-
+        
         boolean nightly = getBoolEnvVar("NIGHTLY_BUILD", false)
         boolean weekly = getBoolEnvVar("WEEKLY_BUILD", false)
-
+        boolean analyzeImage = getBoolEnvVar("DO_ISAFW", false)
+        
         // Build the images
         try {
             boolean buildUpdate = variantName.startsWith("rpi")
@@ -268,8 +274,8 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
             archiveCache(yoctoDir, doArchiveCache, yoctoCacheArchivePath)
 
             // Check if we want to store the images, SDK and artifacts as well
-            boolean doArchive = getBoolEnvVar("ARCHIVE_ARTIFACTS", false)
-            if (nightly || weekly || doArchive) {
+            boolean doArchiveCache = getBoolEnvVar("ARCHIVE_ARTIFACTS", false)
+            if (nightly || weekly || doArchiveCache) {
                 echo "Nightly, Weekly or ARCHIVE_ARTIFACTS was set"
                 archiveImagesAndSDK(yoctoDir, variantName)
             }

--- a/conf/isafw.bblayers.conf
+++ b/conf/isafw.bblayers.conf
@@ -1,0 +1,3 @@
+BBLAYERS += " \
+     ${BSPDIR}/sources/meta-security-isafw \
+"

--- a/conf/isafw.local.conf
+++ b/conf/isafw.local.conf
@@ -1,0 +1,1 @@
+INHERIT += "isafw" 

--- a/pelux.xml
+++ b/pelux.xml
@@ -55,6 +55,12 @@
            name="meta-virtualization"
            path="sources/meta-virtualization"/>
 
+  <project remote="github"
+           upstream="master"
+           revision="7110b507322ceb8aa1ff28c7eebf4c0be695d939"
+           name="01org/meta-security-isafw"
+           path="sources/meta-security-isafw"/>
+           
   <!-- GENIVI stuff -->
   <project remote="github"
            upstream="14.x-sumo"


### PR DESCRIPTION
Integrated to run on our CI/CD environment via a local variable.
When triggered, it will save the logs and release them as artifacts
together with other images.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>