### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="sumo"
-           revision="fa962ec72f8a8337eaae71ab622e340f6ef56395"
+           revision="58e82c451071d0e257da6088cf643e636282084c"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
- brief-yoctoprojectqs, dev-manual: Updated poky clone examples.
- poky.ent: Updated release date to "January 2019".
- Documentation: Updated dates for 2.5.2 release.
- testsdk: Improvements to the json logging
- testimage: Improvements to the json logging
- oeqa/selftest/esdk: Fix typo causing test failure
- default-versions.inc: Make PREFERRED_VERSION_openssl* overwritable
- oeqa/selftest/esdk: Ensure parent directory exists
- image-buildinfo,oeqa/selftest/containerimage: Ensure image-buildinfo doesn't break tests
- oeqa/utils/metadata: Allow to function without the git module
- oeqa/selftest: Standardize json logging output directory
- oeqa/selftest: Improvements to the json logging
- testsdk.bbclass: write testresult to json files
- testimage.bbclass: write testresult to json files
- oeqa/selftest/context: write testresult to json files
- oeqa/runner: Sort the test result output by result class
- oeqa/runner: Always show a summary of success/fail/error/skip counts
- oeqa/runtime/ptest: Inject results+logs into stored json results file
- oeqa/core/runner: write testresult to json files
- oeqa/core/runner: refactor for OEQA to write json testresult
- oeqa: Remove xmlrunner
- oeqa/runner: Simplify code
- oeqa/core/threaded: Remove in favour of using concurrenttests
- oeqa/runner: Ensure we don't print misleading results output
- oeqa/core/runner: Improve test case comparision
- oeqa/selftest/context: Improve log file handling
- oeqa/utils/qemurunner.py: Fix python regex warnings
- oeqa/selftest/context: Replace deprecated imp module usage
- oeqa/utils/commands: Avoid unclosed file warnings
- oeqa/loader: Fix deprecation warning
- oeqa/selftest/esdk: run selftest inside workdir not /tmp
- oeqa: don't litter /tmp with temporary directories
- oeqa/utils/qemurunner: Avoid tracebacks on closed files
- oeqa/selftest/runqemu: Improve testcase failure handling
- oeqa/oelib/path: don't leak temporary directories
- oeqa/selftest/buildoptions: Ensure diskmon tests run consistently
- oeqa/selftest/buildoptions: Improve ccache test
- oeqa/qemurunner: Remove resource python warnings
- oeqa/utils/commands: Avoid log message duplication
- oeqa/utils/qemurunner: Fix python ResourceWarning for unclosed file
- oeqa/utils/commands: Add extra qemu failure logging
- oeqa/selftest/buildoptions: Improve ccache test failure output
- oeqa/selftest/case: Use bb.utils.remove() instead of shutil.remove()
- oeqa/selftest/signing: Use do_populate_lic target instead of do_package
- oeqa/selftest/signing: Allow tests not to need gpg on the host
- oeqa/selftest/signing: Skip tests if gpg isn't found
- scripts/runqemu: Improve lockfile handling for python with close_fd=True
- scripts/runqemu: Tidy up lock handling code
- scripts/runqemu: Replace subprocess.run() for compatibilty
- documentation: Prepared for 2.5.2 document release
- bitbake: bitbake-user-manual: Added "usehead" parameter.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>