### PR TITLE
Vagrantfile: fix path to Yocto cache

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,8 @@ Vagrant.configure(2) do |config|
 
     # If an archive path for the yocto cache is given, we mount it into the vm
     # using the same path as on the host.
-    unless ENV['YOCTO_CACHE_PATH'].to_s.strip.empty?
-      config.vm.synced_folder ENV['YOCTO_CACHE_PATH'], ENV['YOCTO_CACHE_PATH']
+    unless ENV['YOCTO_CACHE_URL'].to_s.strip.empty?
+      config.vm.synced_folder ENV['YOCTO_CACHE_URL'], ENV['YOCTO_CACHE_URL']
     else
       config.vm.synced_folder "/var/yocto-cache", "/var/yocto-cache"
     end


### PR DESCRIPTION
YOCTO_CACHE_URL environment variable is used by Jenkins to set path to
the Yocto cache, not the currently specified YOCTO_CACHE_PATH.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>