### PR TITLE
copy-to-archive: copy only the timestamped image

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -39,19 +39,19 @@ fi
 # If there is an Intel directory
 if [ -d ${IMAGE_DIR}/${INTEL_ARCH} ]; then
     echo "Archiving Intel image to $ARCHIVE_DIR"
-    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
 fi
 
 # If there is an ARP directory
 if [ -d ${IMAGE_DIR}/${ARP_ARCH} ]; then
     echo "Archiving ARP image to $ARCHIVE_DIR"
-    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
 fi
 
 # If there is an RPI directory
 if [ -d ${IMAGE_DIR}/${RPI_ARCH} ]; then
     echo "Archiving RPI image to $ARCHIVE_DIR"
-    mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*.rpi-sdimg $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*rootfs.rpi-sdimg $ARCHIVE_DIR
 fi
 
 # Copy the SDK


### PR DESCRIPTION
Currently we copy duplicate images. One with the timestamp
and the other without the timestamp.

This change copies only the one with a timestamp.

Signed-off-by: Fisnik Hajredini <fisnikhajredini@gmail.com>