### PR TITLE
pelux.xml: use https instead of git

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -6,9 +6,9 @@
 
   <!-- Remotes -->
   <remote fetch="git://git.openembedded.org" name="oe"/>
-  <remote fetch="git://git.yoctoproject.org" name="yocto"/>
-  <remote fetch="git://github.com"           name="github"/>
-  <remote fetch="git://code.qt.io"           name="code.qt"/>
+  <remote fetch="https://yoctoproject.org" name="yocto"/>
+  <remote fetch="https://github.com"           name="github"/>
+  <remote fetch="https://code.qt.io"           name="code.qt"/>
 
   <!-- Base stuff -->
   <project remote="yocto"


### PR DESCRIPTION
HTTPS is normally recommended over GIT for anonymous clones since:
- git and ssh are blocked in some networks
- https will always verify the server automatically, using certificate
  authorities, adding additional layer of security

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>