### PR TITLE
pelux.xml: bump poky and meta-openembedded

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,13 +13,13 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="f5a57e939e626a5b7c6de5b51799ca602ed355ed"
+           revision="9dfebdaf7af11b69006996f3253e435bce0dfbfb"
            name="poky"
            path="sources/poky"/>
 
   <project remote="oe"
            upstream="thud"
-           revision="6ef9657068492d4644079c88f2adee9c3cac9543"
+           revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005"
            name="meta-openembedded"
            path="sources/meta-openembedded"/>
 


### PR DESCRIPTION
poky:
- build-appliance-image: Update to thud head revision
- poky.conf: Bump version for 2.6.2
- yocto-uninative: Update to 2.4
- yocto-uninative: Correct sha256sum for aarch64
- scripts/wic: Be consistent about how we call bitbake
- oeqa/utils/gitarchive: Handle case where parent is only on origin
- resulttool/manualexecution: To output right test case id
- resulttool/report: Enable roll-up report for a commit
- scripts/resulttool: Enable manual result store and regression
- resulttool/regression: Ensure regressoin results are sorted
- resulttool/store: Fix missing variable causing testresult corruption
- resulttool/report: Ensure ptest results are sorted
- resulttool/report: Ensure test suites with no results show up on the report
- resulttool/report: Handle missing metadata sections more cleanly
- resulttool/store: Handle results files for multiple revisions
- resulttool/resultutils: Avoids tracebacks for missing logs
- resulttool: Improvements to allow integration to the autobuilde
- scripts/resulttool: enable manual execution and result creation
- resulttool: enable merge, store, report and regression analysis
- libpam: libpamc is licensed under its own BSD-style licence
- target-sdk-provides-dummy: add more perl modules to avoid populate_sdk failure
- lttng-tools: update to 2.9.11
- lttng-modules: update to 2.10.9
- lttng-ust: update to 2.10.3
- rm_work: sort the value of do_build dependencies
- send-error-report: Add --no-ssl to use http protocol
- libpng: fix CVE-2019-7317
- libsndfile1: Security fix CVE-2018-19432
- kernel: Ensure an initramfs is added if configured
- ca-certificates: upgrade 20180409 -> 20190110
- systemd: fix CVE-2019-6454
- systemd: Update recent CVE patches
- target-sdk-provides-dummy: Extend to -dev and -src packages
- systemd: RDEPENDS on util-linux-umount
- target-sdk-provides-dummy: add perl-module-overload
- bitbake: gitsm: The fetcher did not process some recursive submodules properly.
- bitbake: gitsmy.py: Fix unpack of submodules of submodules
- bitbake: gitsm.py: Fix relative URLs
- bitbake: gitsm.py: Refactor the functions and simplify the class
- bitbake: gitsm.py: Rework the shallow fetcher and test case
- bitbake: gitsm.py: revise unpack
- bitbake: gitsm.py: Optimize code and attempt to resolve locking issue	Mark Hatle
- bitbake: tests/fetch.py: Add alternative gitsm test case
- bitbake: gitsm.py: Add support for alternative URL formats from submodule files
- bitbake: gitsm.py: Fix when a submodule is defined, but not initialized
- ref-manual: Fixed SRC_URI cut-and-paste error.

meta-openembedded:
- rtmpdump: Switch to using GNU TLS instead of openssl10
- Split ntpq into an own package
- wireless-regdb: update 2018.05.31 -> 2018.10.24
- python3-blivetgui: Fix _supported_filesystems crash
- mosquitto: fully switch over to using PACKAGECONFIG_CONFARGS
- mosquitto: fix build in systemd environments

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>