### PR TITLE
yocto.groovy: make yocto compatibility tests optional

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -255,6 +255,7 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
         boolean doArchiveCache = getBoolEnvVar("ARCHIVE_CACHE", false)
         boolean smokeTests = getBoolEnvVar("SMOKE_TEST", false)
         boolean bitbakeTests = getBoolEnvVar("BITBAKE_TEST", false)
+        boolean yoctoCompatTest = getBoolEnvVar("YOCTO_COMPATIBILITY_TEST", false)
         setupBitbake(yoctoDir, templateConf, doArchiveCache, smokeTests, analyzeImage)
         setupCache(yoctoDir, yoctoCacheURL)
 
@@ -262,7 +263,9 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
         try {
             boolean buildUpdate = variantName.startsWith("rpi")
             buildImageAndSDK(yoctoDir, imageName, variantName, buildUpdate)
-            runYoctoCheckLayer(yoctoDir)
+            if (yoctoCompatTest) {
+                runYoctoCheckLayer(yoctoDir)
+            }
             if (smokeTests) {
                 runSmokeTests(yoctoDir, imageName)
                 if(bitbakeTests) {


### PR DESCRIPTION
Yocto compatibility tests produce inaccurate and confusing results, e.g
they looks for dependencies of every existing package in the tested
layer and if it is not found, the test fails, even though the dependency
is present in another layer that is not used by PELUX and therefore not
included in our bblayers.conf.

Tests also do not distinguish between critical and non-critical errors.

Those tests should occasionally be executed locally instead to ensure
PELUX layers are compatible with the Yocto project.

Disable tests to save on build time.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>