### PR TITLE
Dockerfile: remove duplicate package installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ USER root
 # like explained here: https://stackoverflow.com/a/37727984
 RUN apt-get update && apt-get install -y \
         openssh-server \
-        inetutils-ping \
         iptables \
         cvs \
-        subversion \
         coreutils \
         python3-pip \
         libfdt1 \
@@ -26,7 +24,6 @@ RUN apt-get update && apt-get install -y \
         graphviz \
         qemu-user \
         g++-multilib \
-        gcc-multilib \
         curl \
         repo \
         rsync \


### PR DESCRIPTION
Removed installation of packages that are already installed by the
inherited image, crops/yocto:ubuntu-16.04-base.

The inherited docker image: https://github.com/crops/yocto-dockerfiles/blob/master/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>