### PR TITLE
Dockerfile: remove inheritance of crops/yocto image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crops/yocto:ubuntu-16.04-base
+FROM ubuntu:16.04
 
 LABEL description="PELUX Yocto build environment"
 
@@ -10,24 +10,48 @@ USER root
 
 # Install dependencies in one command to avoid potential use of previous cache
 # like explained here: https://stackoverflow.com/a/37727984
-RUN apt-get update && apt-get install -y \
-        openssh-server \
-        iptables \
-        cvs \
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        chrpath \
         coreutils \
-        python3-pip \
-        libfdt1 \
-        python-pysqlite2 \
-        help2man \
-        libxml2-utils \
-        libsdl1.2-dev \
-        graphviz \
-        qemu-user \
-        g++-multilib \
+        cpio \
         curl \
+        cvs \
+        diffstat \
+        g++-multilib \
+        gawk \
+        gcc-multilib \
+        git-core \
+        graphviz \
+        help2man \
+        iptables \
+        iputils-ping \
+        libfdt1 \
+        libsdl1.2-dev \
+        libxml2-utils \
+        locales \
+        m4 \
+        openssh-server \
+        python \
+        python-pysqlite2 \
+        python3 \
+        python3-pip \
+        qemu-user \
         repo \
         rsync \
-        m4
+        screen \
+        socat \
+        subversion \
+        sudo \
+        sysstat \
+        texinfo \
+        tmux \
+        unzip \
+        wget \
+        xz-utils
+
+RUN apt-get clean
 
 # For Yocto bitbake -c testimage XML reporting
 RUN pip3 install unittest-xml-reporting
@@ -36,14 +60,16 @@ RUN pip3 install unittest-xml-reporting
 # The downloaded script is needed since git-lfs is not available per default for Ubuntu 16.04
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash && sudo apt-get install -y git-lfs
 
-
 # Remove all apt lists to avoid build caching
 RUN rm -rf /var/lib/apt/lists/*
 
 # en_US.utf8 is required by Yocto sanity check
+RUN /usr/sbin/locale-gen en_US.UTF-8
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN echo 'export LC_ALL="en_US.UTF-8"' >> /etc/profile
 ENV LANG en_US.utf8
+
+RUN useradd -U -m yoctouser
 
 # Make sure the user/groupID matches the UID/GID given to Docker. This is so that mounted
 # dirs will get the correct permissions
@@ -52,9 +78,13 @@ RUN groupmod --gid $groupid yoctouser
 RUN echo 'yoctouser:yoctouser' | chpasswd
 RUN echo 'yoctouser ALL=(ALL) NOPASSWD:SETENV: ALL' > /etc/sudoers.d/yoctouser
 
-# Set up git and repo
 USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash
+
+# Set up git and repo
 ADD --chown=yoctouser:yoctouser cookbook /tmp/cookbook/
+
 # Set up git config --global stuff
 RUN /tmp/cookbook/system-config/vagrant-ssh-user.sh
 


### PR DESCRIPTION
The Yocto Project recommends using Docker containers from crops for
building Yocto based projects.

With @ee336cd96e we have started using crops/yocto:ubuntu-16.04-base
as a base for our container, which in theory was supposed to make
maintenance of our Dockerfile eaiser.

On practice, Docker container from crops happened to have lots
unnecessary packages installed, e.g. Fluxbox and VNC server.

By removing inheritance of crops/yocto:ubuntu-16.04-base we make our
image more lightweight and gain more control over its content.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>