### PR TITLE
pelux.xml: bump meta-ivi

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -64,7 +64,7 @@
   <!-- GENIVI stuff -->
   <project remote="github"
            upstream="master"
-           revision="92479341e6352dd7755e741174d7e393f64ab908"
+           revision="189f536d4e8e0966035afeb0679b1e1dd240d1b7"
            name="GENIVI/meta-ivi"
            path="sources/meta-ivi"/>
 


### PR DESCRIPTION
The only noticable change is the latest dlt-daemon.

Changelog:
- README.md: Update meta-gpl2 to tip of thud
- README.md: Update meta-openembedded to tip of thud
- README.md: Update poky to tip of thud
- README.md: Update poky commit to thud-20.0.0
- wayland-ivi-extension: update EGLWLMockNavigation
- dlt-daemon: bump to 2.18.1
- ci-build: use gfx/mmp pkgs for r-car gen 3 YBSP v3.15.0 and YP 2.6
- MAINTAINERS: remove maintainer's email

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>