### PR TITLE
Dockerfile: destroy container after 6 hours

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,4 +97,4 @@ RUN /tmp/cookbook/system-config/vagrant-ssh-user.sh
 USER root
 RUN mkdir /var/run/sshd
 EXPOSE 22
-CMD  ["/usr/sbin/sshd", "-D"]
+CMD  ["timeout", "--signal=SIGKILL", "21600", "/usr/sbin/sshd", "-D"]

--- a/hooks/build
+++ b/hooks/build
@@ -5,6 +5,6 @@ GROUPID=1003
 
 echo "------ DOCKER HUB BUILD HOOK - START -------"
 
-docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%d %H:%M:%S"` --build-arg userid=$USERID --build-arg groupid=$GROUPID -t $IMAGE_NAME .
+docker build --build-arg userid=$USERID --build-arg groupid=$GROUPID -t $IMAGE_NAME .
 
 echo "------ DOCKER HUB BUILD HOOK - END -------"


### PR DESCRIPTION
In case of force abort of jenkins job container
remains up and running until next run on this node.
Overnight docker-prune job cannot clean it up as it is not stopped.
This fix will help us to release capacity for other jobs

Signed-off-by: Dmytro Iurchuk <diurchuk@luxoft.com>