### PR TITLE
yocto.groovy: Remove catching while building

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -260,9 +260,6 @@ void buildManifest(String variantName, String imageName, String layerToReplace="
                 }
             }
 
-        }  catch(e) {
-            echo "Bitbake process failed!"
-            println(e.getMessage())
         } finally {
             // Archive cache even if there were errors.
             archiveCache(yoctoDir, doArchiveCache, yoctoCacheArchivePath)


### PR DESCRIPTION
The catch was added to understand an error. With this catch on, the
builds will always be successful/green and finding a failed build
will be hard.

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>