### PR TITLE
Thud new test format

### DIFF
--- a/ci-scripts/yocto.groovy
+++ b/ci-scripts/yocto.groovy
@@ -117,6 +117,12 @@ void runSmokeTests(String yoctoDir, String imageName) {
         stage("Publish smoke test results") {
             reportsDir="/vagrant/${archiveDir}/test_reports/${imageName}/"
             vagrant("mkdir -p ${reportsDir}")
+            if (fileExists("pelux_yocto/build/tmp/log/oeqa/testresults.json")) {
+                // Since `thud`, poky test report consists of a single JSON
+                // file; we need to convert it into jUnit format.
+                vagrant("mkdir -p ${yoctoDir}/build/TestResults/")
+                vagrant("cd ${yoctoDir}/build/TestResults/ && /vagrant/cookbook/yocto/json2junit.py ${yoctoDir}/build/tmp/log/oeqa/testresults.json")
+            }
             vagrant("cp -a ${yoctoDir}/build/TestResults* ${reportsDir}")
             junit "${archiveDir}/test_reports/${imageName}/TestResults*/*.xml"
         }


### PR DESCRIPTION
Since Yocto `thud`, poky's test report is delivered as a non standard JSON file, which Jenkins and other tools don't understand. For this reason, add a script to convert it into jUnit files.

While the script has been successfully tested in another (proprietary) project, the groovy parts are an adaptation of what I have in the other project. I couldn't test them and I'm not sure when I'll get the time to properly do it. I will eventually get to it, but if you have a machine ready to test this, that would be much faster :-)