### PR TITLE
pelux.xml: bump meta-bistro

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -26,7 +26,7 @@
   <!-- Pelagicore/Luxoft stuff -->
   <project remote="github"
            upstream="master"
-           revision="d524a251acc592e8724683e5bd98d945e023500a"
+           revision="f8fe04f2b2e4a87e6eb7e6c604119724fc032e95"
            name="Pelagicore/meta-bistro"
            path="sources/meta-bistro"/>
 


### PR DESCRIPTION
To get fix for dlt-system.service always failing nightly automatic flashing jobs due to binary not being installed. "systemctl is-system-running" is used to test and it reports "degraded" if a service has failed to start.