### PR TITLE
pelux.xml: bump meta-openembedded

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -19,7 +19,7 @@
 
   <project remote="oe"
            upstream="thud"
-           revision="4cd3a39f22a2712bfa8fc657d09fe2c7765a4005"
+           revision="9b3b907f30b0d5b92d58c7e68289184fda733d3e"
            name="meta-openembedded"
            path="sources/meta-openembedded"/>
 


### PR DESCRIPTION
Changelog:
- netkit-rsh: add tag to CVE patch
- netkit-rsh: security fixes
- netkit-rsh: don't build under musl
- ccid: fix SRC_URI
- mariadb: update to 5.5.64
- ntp: upgrade 4.2.8p12 -> 4.2.8p13
- cpupower: remove LIC_FILES_CHKSUM

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>