### PR TITLE
pelux.xml: bump meta-intel

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -84,7 +84,7 @@
   <!-- BSP layers -->
   <project remote="yocto"
            upstream="thud"
-           revision="27dadcfc7bc0de70328b02fecb841608389d22fc"
+           revision="3c45215fe075ddaa892bc87f969f50684a7062b4"
            name="meta-intel"
            path="sources/meta-intel"/>
 


### PR DESCRIPTION
Stable kernel updates:
- intel-microcode: upgrade to 20190514a
- linux-intel_4.19: update to v4.19.40
- linux-intel-rt/4.19: update meta SRCREVs to v4.19.31
- linux-intel-rt/4.14: update to v4.14.106
- linux-intel/4.19: update to v4.19.34
- linux-intel_4.14: update to v4.14.110
- linux-intel/4.19: update to v4.19.28
- linux-intel_4.14: update to v4.14.101
- linux-intel/4.19: update to v4.19.23

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>