### PR TITLE
hooks/build: pass UID/GID of user that builds container

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-USERID=1003
-GROUPID=1003
+USERID=$(id -u)
+GROUPID=$(id -g)
 
 echo "------ DOCKER HUB BUILD HOOK - START -------"
 


### PR DESCRIPTION
Instead of having hardcoded user and group IDs, pass IDs of the user
container is build under.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>