### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="8b10c25d3112e1f09dedc5d7d21ee2911d095df5"
+           revision="4d4ffbaf125badc31be1af34b70f471c820ad034"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
For automatic mounting of mass storage devices. A couple of other changes pulled in as well since not bumped in a while.

meta-pelux shortlog:
- Include mount parts of udev-extraconf in Poky
- neptune3-ui: hide mouse cursor
- local.conf: create a bmap file
- mopidy: bump to 2.2.3
- conf/variant: include meta-arp-extras
- meta-arp-extras: new fstab for ARP