### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="4d4ffbaf125badc31be1af34b70f471c820ad034"
+           revision="ee264b83a05cf35b103963ea6c7b17b1bc7f5f29"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
meta-pelux shortlog:

- core-image-pelux: reduce number of IMAGE_INSTALL_append
- core-image-pelux-minimal-dev: remove tools-testapps
- local.conf.sample: add wic.bz2 to IMAGE_FSTYPE
- core-image-pelux: remove unnecessary IMAGE_FSTYPES

Signed-off-by: Fisnik Hajredini <fhajredini@luxoft.com>