### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="823134fb0084dee0fab858845ae26b4371f88c57"
+           revision="26079f1d6af92298494754f8d146cdcdc3edbf69"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
For /media -> /data partition rename and mass storage device auto mounting lsblk fix.

- Add /data partition for RPI images
- Use wic for RPI
- Rename /media partition to /data
- udev-extraconf: add lsblk dependency
- qtbase: remove examples for Raspberry Pi