### PR TITLE
Archive *.wic.bz2 images

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -39,8 +39,8 @@ fi
 # If there is an Intel directory
 if [ -d ${IMAGE_DIR}/${INTEL_ARCH} ]; then
     echo "Archiving Intel image to $ARCHIVE_DIR"
-    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*20*.swu $ARCHIVE_DIR
 fi
 
@@ -48,8 +48,8 @@ fi
 
 if [ -d ${IMAGE_DIR}/${ARP_ARCH} ]; then
     echo "Archiving ARP image to $ARCHIVE_DIR"
-    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*20*.swu $ARCHIVE_DIR
 fi
 

--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -41,6 +41,7 @@ if [ -d ${IMAGE_DIR}/${INTEL_ARCH} ]; then
     echo "Archiving Intel image to $ARCHIVE_DIR"
     mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bz2 $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${INTEL_ARCH}/${IMAGE_BASENAME}-*20*.swu $ARCHIVE_DIR
 fi
 
@@ -50,6 +51,7 @@ if [ -d ${IMAGE_DIR}/${ARP_ARCH} ]; then
     echo "Archiving ARP image to $ARCHIVE_DIR"
     mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bz2 $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${ARP_ARCH}/${IMAGE_BASENAME}-*20*.swu $ARCHIVE_DIR
 fi
 
@@ -58,6 +60,7 @@ if [ -d ${IMAGE_DIR}/${RPI_ARCH} ]; then
     echo "Archiving RPI image to $ARCHIVE_DIR"
     mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*rootfs.wic $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bmap $ARCHIVE_DIR
+    mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*rootfs.wic.bz2 $ARCHIVE_DIR
     mv ${IMAGE_DIR}/${RPI_ARCH}/${IMAGE_BASENAME}-*20*.swu $ARCHIVE_DIR
 fi
 


### PR DESCRIPTION
We want to only archive compressed images but some scripts (MuxPI) still rely on *.wic. Start by just archiving the *.wic.bz2 files so we can test them more easily. Should remove the *.wic ones when they are no longer needed.
