### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -32,7 +32,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="75e13025984000ce153767cb5c9d1ec0c5c9f66e"
+           revision="88c6d295d40a4674a55bbac81b11f80af6936f23"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
For ARP /etc/fstab fix.

meta-pelux shortlog:
- meta-arp-extras: fix wrong UUID:s in /etc/fstab
- linux-raspberrypi: enable CONFIG_USB_FUNCTIONFS
- udev-extraconf: add missing return in mount patch
- udev-extraconf: do not mount swap partitions