### PR TITLE
pelux.xml: bump poky to 2.6.3

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="2dd610cc27c606f731f83047b4766787aab6e6b2"
+           revision="4d63da3fad18264688debf0c3bce4b9d562c9d82"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Yocto 2.6.3 release.

Shortlog:
- uboot-sign.bbclass: Remove tab indentations in python code
- glib: Security fix for CVE-2019-9633
- qemu: Security fixes CVE-2018-20815 CVE-2019-9824
- glibc: backport CVE fixes
- lighttpd: fix CVE-2019-11072
- uninative: Update to 2.6 release
- uninative: Switch from bz2 to xz
- yocto-uninative: Update to 2.5 release
- qemu: Security fix for CVE-2019-12155
- Curl: Securiyt fix CVE-2019-5435 CVE-2019-5436
- wget: Security fix for CVE-2019-5953
- glib-2.0: Security fix for CVE-2019-12450
- Tar: Security fix CVE-2019-0023
- qemu: Security fix for CVE-2018-19489
- wpa_supplicant: Changed systemd template units
- go: update to minor update 1.11.10
- go: Upgrade 1.11.1 -> 1.11.4 minor release
- go-crosssdk: PN should use SDK_SYS, not TARGET_ARCH
- go-target.inc: fix go not found while multilib enabled
- cairo: fix CVE-2018-19876 CVE-2019-6461 CVE-2019-6462
- cups: upgrade to 2.2.10
- cups: upgrade to 2.2.9
- file: Multiple Secruity fixes
- sqlite3: Security fixes for CVE-2018-20505 & 20506
- busybox: Security fixes for CVE-2018-20679 CVE-2019-5747
- python: add a fix for CVE-2019-9948 and CVE-2019-9636
- python: Update to 2.7.16
- qemu: Several CVE fixes
- elfutils: Security fixes CVE-2019-7146,7149,7150
- glibc: Security fix CVE-2019-9169
- ref-manual: Fixed typo for BBMULTICONFIG variable.
- bsp-guide: Fixed build error.
- bsp-guide: Minor edits to Configuring Kernel section.
- bsp.xml: Updated some output examples and the BSP structure
- brief-yoctoprojectqs: Updated examples.
- Documentation: Prepare for 2.6.3 release.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>