### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="4d63da3fad18264688debf0c3bce4b9d562c9d82"
+           revision="d49de3810a81ec20600d00e5681d485fd55eabcf"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Security updates for Thud.

Shortlog:
- expat: fix CVE-2018-20843
- libcroco: fix CVE-2017-7961
- ghostscript: Fix 3 CVEs
- bzip2: fix CVE-2019-12900
- libarchive: integrate security fixes
- gstreamer1.0-plugins-base: fix CVE-2019-9928
- libsdl: CVE fixes
- OpkgPM: use --add-ignore-recommends to process BAD_RECOMMENDATIONS
- opkg: add --ignore-recommends flag
- scripts: Remove deprecated imp module usage

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>