### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -13,7 +13,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="d49de3810a81ec20600d00e5681d485fd55eabcf"
+           revision="cb26830f765f03309c0663352cc5849491271be8"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Seems to be the minishing finishing changes for 2.6.3 release.

Shortlog:
- build-appliance-image: Update to thud head revision
- poky.conf: Bump version for 2.6.3 thud release

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>