### PR TITLE
pelux.xml: switch meta-boot2qt to thud

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -76,7 +76,7 @@
            path="sources/meta-qt5"/>
 
   <project remote="code.qt"
-           upstream="QtAS-5.13.0"
+           upstream="thud"
            revision="e35e0affd05ddddaf3846f292f662984b9bed162"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>


### PR DESCRIPTION
QtAS-5.13.0 branch has been removed from the repository and merged into
thud branch.

Point to the hash of QtAS-5.13.0 to thud merge.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>