### PR TITLE
pelux.xml: switch meta-boot2qt to thud

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -76,7 +76,7 @@
            path="sources/meta-qt5"/>
 
   <project remote="code.qt"
-           upstream="QtAS-5.13.0"
+           upstream="thud"
            revision="7eab9d044f30deda8c0121b40e77aff3d66ffa32"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>


### PR DESCRIPTION
QtAS-5.13.0 branch has been removed from the repository and merged into
thud branch.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>