### PR TITLE
Dockerfile: install bc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ USER root
 # like explained here: https://stackoverflow.com/a/37727984
 RUN apt-get update && \
     apt-get install -y \
+        bc \
         build-essential \
         chrpath \
         coreutils \


### PR DESCRIPTION
bc is required to compile Linux kernel and kernel modules with SDK.

To make sure user will have it installed, bc will be added to HOSTTOOLS
in meta-pelux, therefore Docker image has to have it installed as well
to successfully pass sanity check before building PELUX.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>