### PR TITLE
pelux.xml: bump meta-ivi

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -64,7 +64,7 @@
   <!-- GENIVI stuff -->
   <project remote="github"
            upstream="master"
-           revision="0a0aeecdfeb61f983c8c02c264162527ee8fb51d"
+           revision="4fd8d784db63b2e93724e69a13bac917437390a7"
            name="GENIVI/meta-ivi"
            path="sources/meta-ivi"/>
 


### PR DESCRIPTION
Changes needed to switch to Yocto "Warrior" 2.7.

Shortlog:
- persistent-client-library: add persistence-administrator to RDEPENDS
- audiomanager: rename package_qa_check_staged
- meta-ivi: add warrior to LAYERSERIES_COMPAT

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>