### PR TITLE
yocto.groovy: accept Freescale EULA

### DIFF
--- a/ci-scripts/yocto2.groovy
+++ b/ci-scripts/yocto2.groovy
@@ -22,6 +22,13 @@ void setupBitbake(String yoctoDir, String templateConf, boolean doArchiveCache, 
 
         // Add other settings that are CI specific to the local.conf
         sh "cat /workspace/conf/local.conf.appendix >> ${yoctoDir}/build/conf/local.conf"
+
+        // Uncomment `ACCEPT_FSL_EULA = "1"` to accept the Freescale EULA
+        // in local.conf if ACCEPT_FSL_EULA parameter is set to true
+        if (getBoolEnvVar("ACCEPT_FSL_EULA", false)) {
+            sh "sed -i '/ACCEPT_FSL_EULA/s/^#//g' ${yoctoDir}/build/conf/local.conf"
+        }
+
         // Add settings for smoke testing if needed
         if (smokeTests) {
             stage("Setup local conf for smoke testing and tests export") {


### PR DESCRIPTION
To be able to build some of the Freescale BSP packages, one must accept
the Freescale EULA by adding the following line to local.conf:

  ACCEPT_FSL_EULA = "1"

This line is commented by default to not force a user building PELUX to
accept the license without their consent. Uncomment the line with sed
to build an image. Command won't fail if the line is not present in
the local.conf.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>