### PR TITLE
pelux.xml: fix meta-qt5 branch

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -71,7 +71,7 @@
 
   <!-- Qt + Qt Automotive support stuff -->
   <project remote="code.qt"
-           upstream="5.12"
+           upstream="5.13"
            revision="refs/tags/v5.13.0"
            name="yocto/meta-qt5"
            path="sources/meta-qt5"/>


### PR DESCRIPTION
upstream incorrectly points to the "5.12" branch. repo/git still find
the correct commit, but it looks confusing.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>