### PR TITLE
pelux.xml: switch meta-tegra to thud-l4t-r28.3

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -126,8 +126,8 @@
            path="sources/meta-smarcimx8m"/>
 
   <project remote="github"
-           upstream="thud-l4t-r32.1"
-           revision="29677fe9484eddaa351dd0a05b0a8f8fb15fe075"
+           upstream="thud-l4t-r28.3"
+           revision="a7f117529b3e93cac4f85c642783236f298bc519"
            name="madisongh/meta-tegra"
            path="sources/meta-tegra"/>
 


### PR DESCRIPTION
thud branch of meta-boot2qt currently only supports NVIDIA L4T 28.3.

Switch BSP meta-layer to thud-l4t-r28.3 branch to align Tegra BSP with
Boot to Qt.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>