### PR TITLE
pelux.xml: bump meta-intel

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -85,7 +85,7 @@
   <!-- BSP layers -->
   <project remote="yocto"
            upstream="thud"
-           revision="278f0b5fa2f1836635178bdc770e035d77ae03c7"
+           revision="c200851435f39acd2fe4abbf7a05fbf617833964"
            name="meta-intel"
            path="sources/meta-intel"/>
 


### PR DESCRIPTION
Updates to stable kernels:
- linux-intel-rt/4.14: update to v4.14.134
- linux-intel_4.14: update to v4.14.138
- linux-intel-rt/4.19: update to v4.19.59
- linux-intel/4.19: update to v4.19.62
- linux-intel/4.19: update to v4.19.57
- linux-intel_4.14: update to v4.14.133
- linux-intel-rt/4.19: update to v4.19.50
- linux-intel-rt/4.14: update to v4.14.126
- linux-intel-rt/4.14: update to v4.14.115
- linux-intel/4.14: update to v4.14.127
- linux-intel_4.14: update to v4.14.123
- linux-intel-rt/4.19: update to v4.19.37
- linux-intel/4.19: update to v4.19.55
- linux-intel/4.19: update to v4.19.50

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>