### PR TITLE
pelux.xml: bump meta-bistro and meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -27,13 +27,13 @@
   <!-- Pelagicore/Luxoft stuff -->
   <project remote="github"
            upstream="master"
-           revision="2f18c6e31abb06180a59856831c4a81a41e96929"
+           revision="4fcc81bcac375835ef0e8fefa100a8a362064f12"
            name="Pelagicore/meta-bistro"
            path="sources/meta-bistro"/>
 
   <project remote="github"
            upstream="master"
-           revision="e90d45435081faf6d7f32601b2e6e0aba97a329d"
+           revision="e391455d55ad2514fdaeb0e21c83e80d342bb2d0"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
meta-bistro bump for latest revision of connectivity-manager with a security property on access points.

meta-pelux bump for gtest dependency in Meson fix that breaks bitbake or building with an SDK if a package has been installed that puts gtest source in /usr/src.

meta-bistro shortlog:
- connectivity-manager: update to latest revision

meta-pelux shortlog:
- meson: add temporary patch for not detecting gtest in /usr/src