### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -33,7 +33,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="90f08b175a39c7646b18d301c31f76785fe02e4e"
+           revision="aafbeb9feeb6a22cd41c0ded6c891fdd73ff580b"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
Shortlog:
- variant/arp-intel fix variant name in conf-notes
- variant/arp-intel: remove meta-intel-extras from bblayers
- variant/arp: rename to arp-intel

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>