### PR TITLE
pelux.xml: bump meta-pelux

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -33,7 +33,7 @@
 
   <project remote="github"
            upstream="master"
-           revision="aafbeb9feeb6a22cd41c0ded6c891fdd73ff580b"
+           revision="d70c982705d5f83e0da0680e13cfa713323e2ef0"
            name="Pelagicore/meta-pelux"
            path="sources/meta-pelux"/>
 


### PR DESCRIPTION
Shortlog:
- hunspell-dicts: move recipe to dynamic-layers/b2qt
- variant/arp-intel: remove meta-arp from bblayers
- variant/arp-intel: install arp-driver
- core-image-pelux: remove IMAGE_INSTALL_append_arp
- variant/arp-intel: remove double machine conf inclusion

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>