### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -14,7 +14,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="e6949336479e611a142834b6d9241514cbaeaf80"
+           revision="87d0be72e755954538cdfac86a40ee75e5b33c40"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Shortlog:
- linux-yocto/4.14: update to v4.14.143
- pango: fix CVE-2019-1010238
- patch: backport fixes
- patch: fix CVE-2019-13638
- libxslt: fix CVE-2019-13117 CVE-2019-13118
- libxslt: Cve fix CVE-2019-11068
- python3: Fix CVEs
- python: Fix 3 CVEs
- binutils: Fix 4 CVEs
- dhcp: Replace OE specific patch for compatibility with latest bind with upstream patch
- dhcp: drop lost patch
- dhcp: fix issue with new bind changes
- go: update to 1.11.13, minor updates
- bind: upgrade 9.11.5 -> 9.11.5-P4
- bind: update to latest LTS 9.11.5
- binutils: Security fix for CVE-2019-12972
- binutils: Security fix for CVE-2019-14444
- gcc: Security fix for CVE-2019-14250
- qemu: add a patch fixing the native build on newer kernels
- libcomps: fix CVE-2019-3817
- glib-2.0: fix CVE-2019-13012
- dbus: fix CVE-2019-12749
- curl: fix CVE-2018-16890 CVE-2019-3822 CVE-2019-3823
- python3: fix CVE-2019-9740
- patch: fix CVE-2019-13636
- buildhistory: call a dependency parser only on actual dependency lists

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>