### PR TITLE
pelux.xml: bump meta-boot2qt

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -78,7 +78,7 @@
 
   <project remote="code.qt"
            upstream="5.13.1_QtAS"
-           revision="51e55f1038152a9375735ed2350311760799be94"
+           revision="37adc03475e91f73c54ebbc32ad5bff881788095"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>
 


### PR DESCRIPTION
A bunch of QtAS updates for version 5.13.1.

Shortlog:
- Update automotive sha1s for QtAS 5.13.1
- mingw: Fix bad cmd flag
- Update automotive sha1s for QtAS 5.13.1
- qtlocation: enable all geoservice plugins
- qtsaferenderer: fix installation of missing plugin
- Update automotive sha1s for QtAS 5.13.1
- neptune: hide mouse cursor
- Update automotive sha1s for QtAS 5.13.1
- [qsr] new qsr and neptune services switching, set display for qsr

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>