### PR TITLE
pelux.xml: bump poky to v2.6.4

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -14,7 +14,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="c272ecd65b3c2be9a411a79576d934378025c7bb"
+           revision="47925dc5f93c19d44dcecacb3afb5893a851a4e4"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Shortlog:
- build-appliance-image: Update to thud head revision
- poky.conf: Bump version for 2.6.4 thud release
- curl: Security fix for CVE-2019-5482
- libsolv: Security fix for CVEs: <CVE-2018-20532, CVE-2018-20533, CVE-2018-20534>
- gnutls: Fix CVE-2019-3829 and CVE-2019-3836
- kernel-devsrc: check for localversion files in the kernel source tree
- glibc: Security fix for cve <CVE-2019-6488, CVE-2019-7309>
- arch-arm64.inc: Lower the priority of aarch64 in MACHINEOVERRIDES
- kernel.bbclass: fix installation of modules signing certificates

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>