### PR TITLE
ci-scripts/copy_to_archive: extend list of archived files

### DIFF
--- a/ci-scripts/copy_to_archive
+++ b/ci-scripts/copy_to_archive
@@ -42,10 +42,14 @@ if [ -d ${LOG_DIR}/isafw-logs ]; then
 fi
 
 if [ -f ${LOG_DIR}/cooker/**/console-latest.log ]; then
-    VARIANT=$(basename $(dirname  ${LOG_DIR}/cooker/**/console-latest.log))
-    TIMESTAMP=$(readlink ${LOG_DIR}/cooker/**/console-latest.log)
-    echo "Archiving build console log $ARCHIVE_DIR"
-    cp -p ${LOG_DIR}/cooker/**/console-latest.log $ARCHIVE_DIR/console-${VARIANT}-${TIMESTAMP}
+    shopt -u globstar;
+    for n in $(find ${LOG_DIR}/cooker/** -type f -links 1);
+    do
+        TIMESTAMP=$(basename ${n})
+        VARIANT=$(basename $(dirname ${n}))
+        cp ${n} $ARCHIVE_DIR/console-${VARIANT}-${TIMESTAMP}
+    done;
+    shopt -s globstar;
 fi
 
 # Find the older directory


### PR DESCRIPTION
Extention to store build log from build itself and from update stage
The difference is in filename which contain creation timestamp

Signed-off-by: Dmytro Iurchuk <DIurchuk@luxoft.com>