### PR TITLE
pelux.xml: bump poky

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -14,7 +14,7 @@
   <!-- Base stuff -->
   <project remote="yocto"
            upstream="thud"
-           revision="51f6145f8f99a02df1dad937684f014b0172e72a"
+           revision="8cd3ee6e1a50ad9f40466bcadb236c619c42ef19"
            name="poky"
            path="sources/poky"/>
 


### PR DESCRIPTION
Shortlog:
- linux-yocto/4.14: meta-yocto-bsp update to 143
- meta-yocto-bsp: Bump to the latest stable kernel for the BSPs
- bitbake: fetch2: Ensure cached url data is matched to a datastore
- documentation: Setup for 2.6.4 release
- bitbake: bitbake-worker child process create group before registering SIGTERM handler

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>