### PR TITLE
pelux.xml: sync meta-boot2qt git revision

### DIFF
--- a/pelux.xml
+++ b/pelux.xml
@@ -78,7 +78,7 @@
            path="sources/meta-qt5"/>
 
   <project remote="code.qt"
-           upstream="5.13.1_QtAS"
+           upstream="thud"
            revision="37adc03475e91f73c54ebbc32ad5bff881788095"
            name="yocto/meta-boot2qt"
            path="sources/meta-boot2qt"/>


### PR DESCRIPTION
There is no 5.13.1_QtAS any more in upstream
https://code.qt.io/cgit/yocto/meta-boot2qt.git
Change to thud branch which commit 37adc034 is available.

Signed-off-by: Phong Tran <tranmanphong@gmail.com>